### PR TITLE
Further content tweaks (for the design)

### DIFF
--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -92,7 +92,7 @@
   </div>
 
   <div class="content-l step-one">
-    <h2><strong>{{STEP}} 1: </strong>{% trans page.step1.title %}</h2>
+    <h2 class="content-l_col content-l_col-2-3"><strong>{{STEP}} 1: </strong>{% trans page.step1.title %}</h2>
     <div class="content-l_col content-l_col-2-3">
       <p class="h3 step-one-instructions">{% trans page.step1.instructions %}</p>
       <div class="content-l">
@@ -137,7 +137,7 @@
         </p>
       </div>
       <div class="total-benefits-container">
-        <p class="total-benefits-text h4"><strong>By age 85, your estimated benefits</strong> <span  data-tooltip-target="lifetime" class="cf-icon cf-icon-help-round"></span> <strong>will total</strong> </p>
+        <p class="total-benefits-text h4"><strong>By 85, your estimated benefits</strong> <span  data-tooltip-target="lifetime" class="cf-icon cf-icon-help-round"></span> <strong>will total</strong> </p>
         <div class="tooltip-content" data-tooltip-name="lifetime">
           <p>{% trans tips.lifetime %}</p>
         </div>
@@ -161,7 +161,7 @@
           <h3 class="retirement-age">{% trans "About your early benefit claiming age:" %}</h3>
           <ul>
             <li>{% trans "Any time before your full benefit claiming age." %}</li>
-            <li>{% trans "The earliest age you can claim your benefit is 62." %}</li>
+            <li>{% trans "Earliest age you can claim your benefit is 62." %}</li>
             <li>{% trans "If you claim your benefit before your full claiming age, it will be reduced." %}</li>
           </ul>
         </div>


### PR DESCRIPTION
* Strike “age” from “By age 85…”
* Strike “the” from the second bullet of early benefit claiming age
* Make “Step 1: Explore how your claiming age affects your Social
Security retirement benefits” fit across only the first 2/3 of the page columns