### PR TITLE
Change breakpoints for graph height

### DIFF
--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -484,12 +484,12 @@
       gset.graphWidth = ( $(window).width() - canvasLeft ) * .95;
     }
 
-    if ($(window).width() < 768) {
+    if ($(window).width() < 850) {
       gset.graphHeight = 210;
-    } else if ($(window).width() >= 768 && $(window).width() < 1051) {
+    } else if ($(window).width() >= 850 && $(window).width() < 1045) {
       gset.graphHeight = 380;
     } else {
-      gset.graphHeight = 380;  
+      gset.graphHeight = 380;
     }
     // $( '.selected-retirement-age-container' ).css( 'margin-top', gset.graphHeight + 75 + 'px');
     $( '.y-axis-label' ).css( 'top', gset.graphHeight - 130 + 'px' );


### PR DESCRIPTION
Change the graph height breakpoints in the JavaScript to match the page breakpoints in the CSS

## Changes

- Small graph height now starts at `$(window).width() < 850`
- Medium graph height and large graph height are currently the same, but the medium breakpoint is now `$(window).width() >= 850 && $(window).width() < 1045`

## Testing

- This should be checked at all screen sizes