### PR TITLE
Fix lifestyle buttons to stay highlighted

### DIFF
--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -663,7 +663,7 @@
     $('.step-two .question .lifestyle-btn').click(function() {
       var $container = $(this).closest( '.question' );
       var respTo = $(this).val();
-      $('.step-two .question .lifestyle-btn').removeClass('active');
+      $container.find('.lifestyle-btn').removeClass('active');
       $(this).addClass('active');
 
       $container.find('.lifestyle-img').slideUp();


### PR DESCRIPTION
Lifestyle buttons for each question stay active when answering another question.

## Changes

- Changed the scope of which lifestyle buttons are deactivated when another button is clicked

## Preview

![buttons](https://cloud.githubusercontent.com/assets/1862695/8750200/ff21b8ea-2c73-11e5-9d4b-c5aa541dbb94.png)