### PR TITLE
Show numeric keyboard on touch devices for DOB and salary inputs

### DIFF
--- a/retirement_api/static/retirement/css/claiming.css
+++ b/retirement_api/static/retirement/css/claiming.css
@@ -292,6 +292,26 @@ form {
   width: 90%;
 }
 
+/* Hide spinners in number inputs */
+#claiming-social-security #bd-month::-webkit-outer-spin-button,
+#claiming-social-security #bd-month::-webkit-inner-spin-button,
+#claiming-social-security #bd-day::-webkit-outer-spin-button,
+#claiming-social-security #bd-day::-webkit-inner-spin-button,
+#claiming-social-security #bd-year::-webkit-outer-spin-button,
+#claiming-social-security #bd-year::-webkit-inner-spin-button,
+#claiming-social-security #salary-input::-webkit-outer-spin-button,
+#claiming-social-security #salary-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+#claiming-social-security #bd-month,
+#claiming-social-security #bd-day,
+#claiming-social-security #bd-year,
+#claiming-social-security #salary-input {
+  -moz-appearance:textfield;
+}
+
 #claiming-social-security .benefits-comparison .annual-view {
   display: none;
 }

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -14,8 +14,8 @@
   }
 </script>
     <div id="page">
-        
-        
+
+
       <!-- top banner -->
       <div class="nemo">
         <div class="wrapper-banner">
@@ -42,12 +42,12 @@
                 <a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i><span class="visuallyhidden">Menu</span></a>
                 <h1>
                   <a href="/" class="noStyles">
-                      <img id="logo" 
-                           class="logo__js" 
-                           src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg" 
-                           onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';" 
-                           alt="Consumer Financial Protection Bureau" 
-                           width="262" 
+                      <img id="logo"
+                           class="logo__js"
+                           src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
+                           onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
+                           alt="Consumer Financial Protection Bureau"
+                           width="262"
                            height="66">
                       <noscript>
                         <img id="logo" class="logo__no-js" src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png" alt="Consumer Financial Protection Bureau" width="262" height="66">
@@ -78,13 +78,13 @@
         </header>
       </div>
 
-            
+
 <div id="claiming-social-security" class="claiming-social-security">
   <div id="claiming-hero-bg"></div>
         <div id="wrapper">
         <section id="maincontent">
             <ul class="bread meta">
-                
+
 
             </ul> <!-- /class=bread -->
   <div class="claiming-hero">
@@ -103,9 +103,9 @@
       <div class="content-l">
         <div class="content-l_col content-l_col-1-3 birthdate-inputs">
           <p>{% trans "Date of birth" %}</p>
-          <label for="bd-month" class="input-labels"><input id="bd-month" type="text" maxlength="2" placeholder="MM" value=""></label>
-          <label for="bd-day" class="input-labels"><input id="bd-day" type="text" maxlength="2" placeholder="DD" value=""></label>
-          <label for="bd-year" class="input-labels"><input id="bd-year" type="text" maxlength="4" placeholder="YYYY" value=""></label>
+          <label for="bd-month" class="input-labels"><input id="bd-month" type="number" max="12" maxlength="2" min="1" pattern="[0-9]*" placeholder="MM" value=""></label>
+          <label for="bd-day" class="input-labels"><input id="bd-day" type="number" max="31" maxlength="2" min="1" pattern="[0-9]*" placeholder="DD" value=""></label>
+          <label for="bd-year" class="input-labels"><input id="bd-year" type="number" maxlength="4" pattern="[0-9]*" placeholder="YYYY" value=""></label>
         </div>
         <div class="content-l_col content-l_col-1-3">
           <label for="salary-input" class="input-labels"><p>{% trans "Highest annual work income" %} <span data-tooltip-target="salary" aria-describedby="salary" class="cf-icon cf-icon-help-round"></span></p><input id="salary-input" type="text" maxlength="" placeholder="$" value=""></label>
@@ -128,12 +128,12 @@
   </div>
   <div class="tooltip-content" data-tooltip-name="estimated-benefits" role="tooltip" aria-haspopup="true">
     <p>{% trans tips.estimated_benefits %}</p>
-  </div>  
+  </div>
 
   <div id="graph-container" class="content-l">
     <div class="content-l_col content-l_col-1-3">
       <div class="selected-retirement-age-container">
-        <p class="h3 selected-retirement-age">{% trans "Age" %} 
+        <p class="h3 selected-retirement-age">{% trans "Age" %}
           <span class="selected-retirement-age-value">67</span> <span class="benefit-modification-text">
           {% trans "is after your full benefit claiming age." %}</span>
           <p class="compared-to-full explainer">{% trans "Compared to claiming at your full benefit claiming age." %}</p>
@@ -144,7 +144,7 @@
         <div class="tooltip-content" data-tooltip-name="lifetime" role="tooltip" aria-haspopup="true">
           <p>{% trans tips.lifetime %}</p>
         </div>
-        <p>  
+        <p>
           <span class="lifetime-benefits-value h3"></span>&nbsp;<span class="todays-dollars explainer">({% trans "in today's dollars" %})</span>  <span data-tooltip-target="lifetime" aria-describedby="lifetime" class="cf-icon cf-icon-help-round"></span>
         </p>
       </div>
@@ -175,7 +175,7 @@
         </div>
         <p>{% trans "Remember, claiming age here refers only to your Social Security retirement benefit, and not when you decide to stop working or apply for Medicare." %}</p>
       </div>
-      
+
       <p class="learn-how"><a href="http://www.ssa.gov/OACT/quickcalc/faqs.html#8" class="external-link" target="_blank">{% trans "Learn how estimates are calculated." %}</a></p>
 
     </div>
@@ -230,7 +230,7 @@
       <div class="lifestyle-response" data-responds-to="yes-under50">
         <h4>{% trans questions.sixties.answer_yes_a_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_yes_a|safe %}</p>
-      </div> 
+      </div>
       <div class="lifestyle-response" data-responds-to="yes-over50">
         <h4>{% trans questions.sixties.answer_yes_b_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_yes_b|safe %}</p>
@@ -238,12 +238,12 @@
       <div class="lifestyle-response" data-responds-to="no-under50">
         <h4>{% trans questions.sixties.answer_no_a_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_no_a|safe %}</p>
-      </div> 
+      </div>
       <div class="lifestyle-response" data-responds-to="no-over50">
         <h4>{% trans questions.sixties.answer_no_b_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_no_a|safe %}</p>
         <p><a href="http://www.socialsecurity.gov/planners/retire/stopwork.html" class="external-link" target="_blank"></a></p>
-      </div> 
+      </div>
       <div class="lifestyle-response" data-responds-to="notsure-under50">
         <h4>{% trans questions.sixties.answer_unsure_a_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_unsure_a|safe %}</p>
@@ -379,7 +379,7 @@
       </div>
     </div>
   </div>
-  <hr> 
+  <hr>
   <div class="step-three">
     <h2><strong>{{STEP}} 3: </strong>{% trans page.step3.title %}</h2>
     <div class="hidden-content">
@@ -439,8 +439,8 @@
 </div>
 
 
-                
-      
+
+
 
       <div class="nemo">
         <section id="subnav">
@@ -558,7 +558,7 @@
 
 <script type="text/javascript">
     // If there are no breadcrumbs on this page, remove the ul tag so that screen
-    // readers don't read it (since the ul has nothing in it).  
+    // readers don't read it (since the ul has nothing in it).
     $(function(){
         var numBreadCrumbs = $("ul.bread").children("li").length;
         if(numBreadCrumbs == 0){

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -108,7 +108,7 @@
           <label for="bd-year" class="input-labels"><input id="bd-year" type="number" maxlength="4" pattern="[0-9]*" placeholder="YYYY" value=""></label>
         </div>
         <div class="content-l_col content-l_col-1-3">
-          <label for="salary-input" class="input-labels"><p>{% trans "Highest annual work income" %} <span data-tooltip-target="salary" aria-describedby="salary" class="cf-icon cf-icon-help-round"></span></p><input id="salary-input" type="text" maxlength="" placeholder="$" value=""></label>
+          <label for="salary-input" class="input-labels"><p>{% trans "Highest annual work income" %} <span data-tooltip-target="salary" aria-describedby="salary" class="cf-icon cf-icon-help-round"></span></p><input id="salary-input" type="text" autocapitalize="off" autocomplete="off" autocorrect="off" maxlength="" placeholder="$" value=""></label>
           <div class="tooltip-content" data-tooltip-name="salary" role="tooltip" aria-haspopup="true">
             <p>{% trans tips.salary %}</p>
           </div>


### PR DESCRIPTION
Automatically pull up a numbers-only keyboard for DOB inputs and a numbers-and-symbols keyboard for the salary input on touch devices.

## Additions

- Add JavaScript to coerce touch devices to pull up the numbers-and-symbols keyboard for the salary input
- Add CSS to hide spinner controls for `<input type="number">`

## Changes

- Change DOB fields to `<input type="number">` with appropriate attributes

## Testing

- This definitely needs to be tested on **real** devices before getting merged (so maybe a Vagrant share):
  - Everything seems to be working well on my iPhone 6, but can someone test it out on other iPhones?
  - I don't have an Android phone to test on, so can someone check that out, too?

## Review

- @mistergone: This could use a good front-end code review

## Preview

Here's the numbers-only keyboard the DOB fields should pull up:

![num](https://cloud.githubusercontent.com/assets/1862695/8856319/11f625d2-3138-11e5-9d54-6f1cfc47fcc5.png)

And here's the numbers-and-symbols keyboard for the salary field (since user testing showed having access to the comma was important):

![num-sym](https://cloud.githubusercontent.com/assets/1862695/8856324/15f932fa-3138-11e5-9afc-a45e847cffcd.png)

## Notes

- When the salary input is the first field tapped on on an iPhone, it's sometimes hidden by the keyboard (haven't figured out a good workaround).
- I had to do some JS magic to get browsers to remember a previously entered salary value if you tap on the field a second time, so you'll notice a brief flash of the text in that field in some cases.