### PR TITLE
Small content styling fixes

### DIFF
--- a/retirement_api/static/retirement/css/claiming.css
+++ b/retirement_api/static/retirement/css/claiming.css
@@ -122,6 +122,10 @@ form {
   font-size: 2.125em;
 }
 
+#claiming-social-security .claiming-hero h1 span.header-line {
+  display: block;
+}
+
 #claiming-social-security .claiming-hero p {
   font-size: 1.625em;
 }
@@ -649,6 +653,10 @@ form {
     width: 100%;
   }
 
+  #claiming-social-security .claiming-hero h1 span.header-line {
+    display: inline;
+  }
+
   #claiming-social-security .claiming-hero p {
     margin-bottom: 0px;
   }
@@ -811,6 +819,10 @@ form {
   #claiming-social-security .claiming-hero h1,
   #claiming-social-security .claiming-hero p {
     width: 100%;
+  }
+
+  #claiming-social-security .claiming-hero h1 span.header-line {
+    display: inline;
   }
 
   #claiming-social-security .claiming-hero p {

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -140,10 +140,7 @@
         </p>
       </div>
       <div class="total-benefits-container">
-        <p class="total-benefits-text h4"><strong>By 85, your estimated benefits will total</strong></p>
-        <div class="tooltip-content" data-tooltip-name="lifetime" role="tooltip" aria-haspopup="true">
-          <p>{% trans tips.lifetime %}</p>
-        </div>
+        <p class="total-benefits-text h4"><strong>By 85, an average lifespan, your total benefits will be</strong></p>
         <p>  
           <span class="lifetime-benefits-value h3"></span>&nbsp;<span class="todays-dollars explainer">({% trans "in today's dollars" %})</span>  <span data-tooltip-target="lifetime" aria-describedby="lifetime" class="cf-icon cf-icon-help-round"></span>
         </p>

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -126,9 +126,6 @@
   <div id="estimated-benefits-input" class="estimated-benefits-input">
     <span class="h3">{% trans "Show my estimated benefits as" %}<label><input type="radio" name="benefits-display" value="monthly" checked> {% trans "monthly income" %}</label> <label><input type="radio" name="benefits-display" value="annual"> {% trans "annual income" %}</label> </span>
   </div>
-  <div class="tooltip-content" data-tooltip-name="estimated-benefits" role="tooltip" aria-haspopup="true">
-    <p>{% trans tips.estimated_benefits %}</p>
-  </div>  
 
   <div id="graph-container" class="content-l">
     <div class="content-l_col content-l_col-1-3">
@@ -142,7 +139,7 @@
       <div class="total-benefits-container">
         <p class="total-benefits-text h4"><strong>By 85, an average lifespan, your total benefits will be</strong></p>
         <p>  
-          <span class="lifetime-benefits-value h3"></span>&nbsp;<span class="todays-dollars explainer">({% trans "in today's dollars" %})</span>  <span data-tooltip-target="lifetime" aria-describedby="lifetime" class="cf-icon cf-icon-help-round"></span>
+          <span class="lifetime-benefits-value h3"></span>&nbsp;<span class="todays-dollars explainer">({% trans "in today's dollars" %})</span>
         </p>
       </div>
       <div class="graph-content">


### PR DESCRIPTION
* Fix the line break in the H1 for different device sizes
* Change text around "By 85" and remove tooltip