### PR TITLE
Tooltip fixes

### DIFF
--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -281,6 +281,12 @@
     innerTip.css("left", Math.floor( tipOffset - ( innerTip.outerWidth() / 2 ) ) );
     outerTip.css("left", Math.floor( tipOffset - ( outerTip.outerWidth() / 2 ) ) );
 
+    if (newLeft < 20) {
+      ttc.css('left', 20);
+      innerTip.css('left', $elem.offset().left + ( $elem.width() / 2 ) - ( innerTip.outerWidth() / 2 ) - 20 );
+      outerTip.css('left', $elem.offset().left + ( $elem.width() / 2 ) - ( outerTip.outerWidth() / 2 ) - 20 );
+    }
+
     if ( /iP/i.test(navigator.userAgent) ) { // if userAgent is an iPhone, iPad, iPod
       $('body').css('cursor', 'pointer'); // make the body clickable
     }
@@ -557,7 +563,7 @@
     if ( typeof sliderLine === "object" && typeof sliderLine.remove !== "undefined" ) {
       sliderLine.remove();
     }
-    // draw a new slider line 
+    // draw a new slider line
     sliderLine = barGraph.path( 'M0 ' + ( gset.graphHeight - 20 ) + ' H' + totalWidth );
     sliderLine.attr( { 'stroke': '#E3E4E5', 'stroke-width': 5 } )
   }

--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -272,19 +272,29 @@
     newLeft = $elem.offset().left + ( $elem.outerWidth() / 2 ) - ( ttc.outerWidth(true) / 2 );
     ttc.css( { 'top': newTop, 'left': newLeft } );
 
-    if ( ttc.offset().left + ttc.outerWidth(true) >$(window).width()) {
-        newLeft = $(window).width() - ttc.outerWidth(true) - 20;
-        ttc.css( 'left', newLeft );
-    }
     // check offset again, properly set tips to point to the element clicked
     tipOffset = Math.floor( ttc.outerWidth() / 2 );
     innerTip.css("left", Math.floor( tipOffset - ( innerTip.outerWidth() / 2 ) ) );
     outerTip.css("left", Math.floor( tipOffset - ( outerTip.outerWidth() / 2 ) ) );
 
+    // Prevent tooltip from falling off the left side of screens
     if (newLeft < 20) {
-      ttc.css('left', 20);
-      innerTip.css('left', $elem.offset().left + ( $elem.width() / 2 ) - ( innerTip.outerWidth() / 2 ) - 20 );
-      outerTip.css('left', $elem.offset().left + ( $elem.width() / 2 ) - ( outerTip.outerWidth() / 2 ) - 20 );
+      var elemCenter = $elem.offset().left + ( $elem.width() / 2 ),
+          pagePadding = 20;
+      ttc.css('left', pagePadding);
+      innerTip.css('left', elemCenter - ( innerTip.outerWidth() / 2 ) - pagePadding );
+      outerTip.css('left', elemCenter - ( outerTip.outerWidth() / 2 ) - pagePadding );
+    }
+
+    // Prevent tooltip from falling off the right side of screens
+    if ( ttc.offset().left + ttc.outerWidth(true) >$(window).width()) {
+      var elemCenter = $elem.offset().left + ( $elem.width() / 2 ),
+          elemRightOffset = $(window).width() - elemCenter,
+          pagePadding = 20;
+      newLeft = $(window).width() - ttc.outerWidth(true) - pagePadding;
+      ttc.css( 'left', newLeft );
+      innerTip.css('left', ttc.outerWidth() - ( innerTip.outerWidth() / 2 ) - elemRightOffset + pagePadding );
+      outerTip.css('left', ttc.outerWidth() - ( outerTip.outerWidth() / 2 ) - elemRightOffset + pagePadding );
     }
 
     if ( /iP/i.test(navigator.userAgent) ) { // if userAgent is an iPhone, iPad, iPod


### PR DESCRIPTION
Prevents tooltips from falling off the left side of small screens and lines up tooltip pointers with their triggers when the tooltips are near the edges of the viewport.

## Additions

- Added a check to adjust tooltips positioned off the left edge of the viewport

## Changes

- Modified the check to adjust tooltips positioned off the right edge of the viewport to line the pointers up with their triggers

## Testing

- I tested this in Safari, Chrome, Chrome's device emulator, and my iPhone 6. Could use more testing on any other devices we have handy.

## Review

- @mistergone: Do the changes I made to your tooltip JS look OK?

## Preview

Tooltips near the left edge of the viewport should look like so:

![left](https://cloud.githubusercontent.com/assets/1862695/8911742/59e8c08a-345c-11e5-9ea1-f0d473f3cd1c.png)

And ones near the right edge should look like so:

![right](https://cloud.githubusercontent.com/assets/1862695/8911743/6311c27e-345c-11e5-95d4-3a4b06f500fb.png)