### PR TITLE
update url to reflect new title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - changed title and `h1` to **Before you claim**
 - made content changes based on user testing
 - fixed mobile alignment of graph elements
+- changed final url field to reflect new title
 
 ## 0.1.7
 **2015-07-15**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- [![Build Status](https://travis-ci.org/cfpb/retirement.png)](https://travis-ci.org/cfpb/retirement) [![Coverage Status](https://coveralls.io/repos/cfpb/retirement/badge.svg)](https://coveralls.io/r/cfpb/retirement)
+[![Build Status](https://travis-ci.org/cfpb/retirement.png)](https://travis-ci.org/cfpb/retirement) [![Coverage Status](https://coveralls.io/repos/cfpb/retirement/badge.svg)](https://coveralls.io/r/cfpb/retirement)
 
 # Retirement: Before You Claim
 
@@ -62,7 +62,7 @@ Fire up a development server.
 python manage.py runserver
 ```
 
-The "Before You Claim" page should load at `localhost:8000/claiming-social-security/`.  
+The "Before You Claim" page should load at `localhost:8000/before-you-claim/`.  
 
 ### Usage notes
 - The app is set up to run inside [consumerfinance.gov](http://www.consumerfinance.gov), so if you run it locally, some fonts may not load because of [Cross-Origin Resource Sharing](http://www.w3.org/TR/cors/) policies.

--- a/browser_testing/features/navigation.feature
+++ b/browser_testing/features/navigation.feature
@@ -7,6 +7,7 @@ Feature: verify the navigation tabs/links works according to requirements
 @smoke_testing @landing_page
 Scenario Outline: Test links in the landing page
    Given I navigate to the Retirement landing page
+   And I enter birth and salary info
    When I click on the "<link_name>" link
    Then I should see the "<full_url>" URL with page title "<page_title>"
 

--- a/browser_testing/features/steps/steps_navigation.py
+++ b/browser_testing/features/steps/steps_navigation.py
@@ -17,7 +17,7 @@ HOME = 'index.html'
 @given(u'I navigate to the Retirement landing page')
 @handle_error
 def step(context):
-    context.base.go('retirement/claiming-social-security')
+    context.base.go('retirement/before-you-claim')
 
 
 # @then(u'I should see "{link_name}" displayed in the page title')

--- a/browser_testing/features/steps/steps_navigation.py
+++ b/browser_testing/features/steps/steps_navigation.py
@@ -28,6 +28,16 @@ def step(context):
 #     assert_that(page_title, contains_string(link_name))
 
 
+@given(u'I enter birth and salary info')
+@handle_error
+def step(context):
+    context.base.enter_month('07')
+    context.base.enter_day('07')
+    context.base.enter_year('1970')
+    context.base.enter_income('70000')
+    context.base.get_estimate()
+    Utils().zzz(1)
+
 @when(u'I click on the "{link_name}" link')
 @handle_error
 def step(context, link_name):

--- a/retirement_api/urls.py
+++ b/retirement_api/urls.py
@@ -6,13 +6,15 @@ from django.conf import settings
 admin.autodiscover()
 
 urlpatterns = patterns('',
-#    url(r'^retirement-api/admin/', include(admin.site.urls)),
+    # url(r'^retirement-api/admin/', include(admin.site.urls)),
     url(r'^retirement-api/estimator/$', 'retirement_api.views.estimator', name='estimator'),
     url(r'^retirement-api/estimator/(?P<dob>[^/]+)/(?P<income>\d+)/$', 'retirement_api.views.estimator', name='estimator'),
     url(r'^retirement/retirement-api/estimator/(?P<dob>[^/]+)/(?P<income>\d+)/$', 'retirement_api.views.estimator', name='estimator'),
     url(r'^retirement-api/get-retirement-age/(?P<birth_year>\d+)/$', 'retirement_api.views.get_full_retirement_age', name='get_full_retirement_age'),
-    url(r'^claiming-social-security/$', 'retirement_api.views.claiming', name='claiming'),
-    url(r'^claiming-social-security/es/$', 'retirement_api.views.claiming', {'es': True}),
+    # url(r'^claiming-social-security/$', 'retirement_api.views.claiming', name='claiming'),
+    # url(r'^claiming-social-security/es/$', 'retirement_api.views.claiming', {'es': True}),
+    url(r'^before-you-claim/$', 'retirement_api.views.claiming', name='claiming'),
+    url(r'^before-you-claim/es/$', 'retirement_api.views.claiming', {'es': True}),
 )
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
This implements the new url reflecting the new app title

## Additions
- two urls

## Removals
- old urls

## Changes

- Readme reference to standalone app's url
- browser tests updated

## Testing

- Browser tests have been updated but will fail until this is deployed, because tests run against the live site.

## Review

- @mistergone @marteki @niqjohnson 

## Notes
- we still have a number of class and other references to 'claiming-social-security,' which i see no need to mess with.
- this needs to be paired with a change to server redirects for the old url

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests – BROWSER TESTS WILL FAIL UNTIL DEPLOYMENT
* [x] Project documentation has been updated (including the 'Unreleased' section of the CHANGELOG)
