### PR TITLE
Prevent slider from resetting on window resize

### DIFF
--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -480,10 +480,11 @@
     indicator.attr( { 'fill': '#F8F8F8', 'stroke': '#919395'})
 
     // set up initial indicator text and position
-    selectedAge = SSData.fullAge;
+    if (currentAge === 0) {
+      selectedAge = SSData.fullAge;
+    }
     posX = ages.indexOf( selectedAge ) * gset.barGut + gset.indicatorLeftSet
     indicator.transform( 't' + posX + ',0' );
-    selectedAge = SSData.fullAge;
 
     var start = function () {
       var t = this.transform();


### PR DESCRIPTION
Stop the slider from jumping back to full retirement age when the window is resized (especially in mobile browsers where a `resize` event is fired when the browser hides its chrome as the page is scrolled).

## Changes

- Change `drawIndicator()` to remember user-selected age after they've gotten their estimate

## Testing

- I've tested this in Chrome, Safari, Chrome's device emulator, and my iPhone 6. Seems to be working as expected.

## Review

- @mistergone: Does that new conditional look OK?