### PR TITLE
Change graph's auto-scroll target

### DIFF
--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -220,7 +220,7 @@
           // Scroll graph into view if it's not visible
           if ( isElementInView( '#claim-canvas' ) === false ) {
             $('html, body').animate({
-                scrollTop: $("#estimated-benefits-input").offset().top - 20
+                scrollTop: $('#estimated-benefits-description').offset().top - 20
             }, 300);
           }
         }
@@ -476,7 +476,7 @@
     // greenPath and whiteLines are added to the indicator set
     // indicator.push( greenPath, whiteLines );
 
-    // draw a new slider line 
+    // draw a new slider line
     if ($(window).width() < 850) {
       indicator = barGraph.circle( 0, gset.graphHeight - 10 , 15);
     } else {
@@ -590,7 +590,7 @@
       sliderLine.remove();
     }
 
-    // draw a new slider line 
+    // draw a new slider line
     if ($(window).width() < 850) {
       sliderLine = barGraph.path( 'M0 ' + ( gset.graphHeight - 10 ) + ' H' + totalWidth );
     } else {


### PR DESCRIPTION
Change the graph's auto-scroll point to accommodate the new graph layout

## Changes

- Set the graph's auto-scroll point to the graph header instead of the monthly/annual income toggle

## Testing

- Tested and working on Chrome, Safari, Chrome's device emulator and my iPhone 6.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] Visually tested in supported browsers and devices