### PR TITLE
adjust graph text when consumer is 70 (per issue #118)

### DIFF
--- a/retirement_api/static/retirement/js/claiming-social-security.js
+++ b/retirement_api/static/retirement/js/claiming-social-security.js
@@ -389,19 +389,22 @@
     else {
       $('.graph-content .content-container.full-retirement').show();
     }
-
     if ( selectedAge === SSData.fullAge ) {
-
       if ( SSData.past_fra ) {
-        $('.benefit-modification-text').html( 'is past your full benefit claiming age.' );
-        $('.compared-to-full').hide();
+        if ( SSData.currentAge === 70 ) {
+          $('.benefit-modification-text').html( 'is your maximum benefit claiming age.' );
+          $('.compared-to-full').hide();
+          }
+        else {
+          $('.benefit-modification-text').html( 'is past your full benefit claiming age.' );
+          $('.compared-to-full').hide();
+          }
       }
       else {
         $('.benefit-modification-text').html( 'is your full benefit claiming age.' );
         $('.compared-to-full').hide();
       }
     }
-
     else if ( selectedAge < SSData.fullAge ) {
       var percent = ( SSData['age' + SSData.fullAge] - SSData['age' + selectedAge] ) / SSData['age' + SSData.fullAge];
       percent = Math.abs( Math.round( percent * 100 ) );


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- add conditional to handle consumers who are 70 years old

## Testing

- if testing in UnityBox, be sure to run `python manage.py collectstatic` before checking

## Review

- @niqjohnson @marteki 


## Screenshots
<img width="750" alt="age70" src="https://cloud.githubusercontent.com/assets/515885/9074080/826718a8-3ad4-11e5-9a5e-97f3dbe49592.png">

## Checklist
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [x] Visually tested
