### PR TITLE
Disable autocomplete for DOB and salary inputs

### DIFF
--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -14,8 +14,8 @@
   }
 </script>
     <div id="page">
-        
-        
+
+
       <!-- top banner -->
       <div class="nemo">
         <div class="wrapper-banner">
@@ -42,12 +42,12 @@
                 <a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i><span class="visuallyhidden">Menu</span></a>
                 <h1>
                   <a href="/" class="noStyles">
-                      <img id="logo" 
-                           class="logo__js" 
-                           src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg" 
-                           onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';" 
-                           alt="Consumer Financial Protection Bureau" 
-                           width="262" 
+                      <img id="logo"
+                           class="logo__js"
+                           src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
+                           onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
+                           alt="Consumer Financial Protection Bureau"
+                           width="262"
                            height="66">
                       <noscript>
                         <img id="logo" class="logo__no-js" src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png" alt="Consumer Financial Protection Bureau" width="262" height="66">
@@ -78,13 +78,13 @@
         </header>
       </div>
 
-            
+
 <div id="claiming-social-security" class="claiming-social-security">
   <div id="claiming-hero-bg"></div>
         <div id="wrapper">
         <section id="maincontent">
             <ul class="bread meta">
-                
+
 
             </ul> <!-- /class=bread -->
   <div class="claiming-hero">
@@ -103,12 +103,12 @@
       <div class="content-l">
         <div class="content-l_col content-l_col-1-3 birthdate-inputs">
           <p>{% trans "Date of birth" %}</p>
-          <label for="bd-month" class="input-labels"><input id="bd-month" type="text" maxlength="2" placeholder="MM" value=""></label>
-          <label for="bd-day" class="input-labels"><input id="bd-day" type="text" maxlength="2" placeholder="DD" value=""></label>
-          <label for="bd-year" class="input-labels"><input id="bd-year" type="text" maxlength="4" placeholder="YYYY" value=""></label>
+          <label for="bd-month" class="input-labels"><input id="bd-month" type="text" maxlength="2" placeholder="MM" value="" autocapitalize="none" autocomplete="off" autocorrect="off" spellcheck="false"></label>
+          <label for="bd-day" class="input-labels"><input id="bd-day" type="text" maxlength="2" placeholder="DD" value="" autocapitalize="none" autocomplete="off" autocorrect="off" spellcheck="false"></label>
+          <label for="bd-year" class="input-labels"><input id="bd-year" type="text" maxlength="4" placeholder="YYYY" value="" autocapitalize="none" autocomplete="off" autocorrect="off" spellcheck="false"></label>
         </div>
         <div class="content-l_col content-l_col-1-3">
-          <label for="salary-input" class="input-labels"><p>{% trans "Highest annual work income" %} <span data-tooltip-target="salary" aria-describedby="salary" class="cf-icon cf-icon-help-round"></span></p><input id="salary-input" type="text" maxlength="" placeholder="$" value=""></label>
+          <label for="salary-input" class="input-labels"><p>{% trans "Highest annual work income" %} <span data-tooltip-target="salary" aria-describedby="salary" class="cf-icon cf-icon-help-round"></span></p><input id="salary-input" type="text" maxlength="" placeholder="$" value="" autocapitalize="none" autocomplete="off" autocorrect="off" spellcheck="false"></label>
           <div class="tooltip-content" data-tooltip-name="salary" role="tooltip" aria-haspopup="true">
             <p>{% trans tips.salary %}</p>
           </div>
@@ -131,7 +131,7 @@
   <div id="graph-container" class="content-l step-one-hidden">
     <div class="content-l_col content-l_col-1-3">
       <div class="selected-retirement-age-container">
-        <p class="h3 selected-retirement-age">{% trans "Age" %} 
+        <p class="h3 selected-retirement-age">{% trans "Age" %}
           <span class="selected-retirement-age-value">67</span> <span class="benefit-modification-text">
           {% trans "is after your full benefit claiming age." %}</span>
           <p class="compared-to-full explainer">{% trans "Compared to claiming at your full benefit claiming age." %}</p>
@@ -139,7 +139,7 @@
       </div>
       <div class="total-benefits-container">
         <p class="total-benefits-text h4"><strong>{% trans "By 85, an average lifespan, your total benefits will be" %}</strong></p>
-        <p>  
+        <p>
           <span class="lifetime-benefits-value h3"></span>&nbsp;<span class="todays-dollars explainer">({% trans "in today's dollars" %})</span>
         </p>
       </div>
@@ -170,7 +170,7 @@
         </div>
         <p>{% trans "Remember, claiming age here refers only to your Social Security retirement benefit, and not when you decide to stop working or apply for Medicare." %}</p>
       </div>
-      
+
       <p class="learn-how"><a href="http://www.ssa.gov/OACT/quickcalc/faqs.html#8" class="external-link" target="_blank">{% trans "Learn how estimates are calculated." %}</a></p>
 
     </div>
@@ -228,7 +228,7 @@
       <div class="lifestyle-response" data-responds-to="yes-under50">
         <h4>{% trans questions.sixties.answer_yes_a_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_yes_a|safe %}</p>
-      </div> 
+      </div>
       <div class="lifestyle-response" data-responds-to="yes-over50">
         <h4>{% trans questions.sixties.answer_yes_b_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_yes_b|safe %}</p>
@@ -236,12 +236,12 @@
       <div class="lifestyle-response" data-responds-to="no-under50">
         <h4>{% trans questions.sixties.answer_no_a_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_no_a|safe %}</p>
-      </div> 
+      </div>
       <div class="lifestyle-response" data-responds-to="no-over50">
         <h4>{% trans questions.sixties.answer_no_b_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_no_a|safe %}</p>
         <p><a href="http://www.socialsecurity.gov/planners/retire/stopwork.html" class="external-link" target="_blank"></a></p>
-      </div> 
+      </div>
       <div class="lifestyle-response" data-responds-to="notsure-under50">
         <h4>{% trans questions.sixties.answer_unsure_a_subhed|safe %}</h4>
         <p>{% trans questions.sixties.answer_unsure_a|safe %}</p>
@@ -377,7 +377,7 @@
       </div>
     </div>
   </div>
-  <hr> 
+  <hr>
   <div class="step-three">
     <h2><strong>{{STEP}} 3: </strong>{% trans page.step3.title %}</h2>
     <div class="hidden-content">
@@ -437,8 +437,8 @@
 </div>
 
 
-                
-      
+
+
 
       <div class="nemo">
         <section id="subnav">
@@ -556,7 +556,7 @@
 
 <script type="text/javascript">
     // If there are no breadcrumbs on this page, remove the ul tag so that screen
-    // readers don't read it (since the ul has nothing in it).  
+    // readers don't read it (since the ul has nothing in it).
     $(function(){
         var numBreadCrumbs = $("ul.bread").children("li").length;
         if(numBreadCrumbs == 0){


### PR DESCRIPTION
Disable autocapitalize, autocomplete, autocorrect, and spellcheck for DOB and salary inputs. This change is mostly to prevent cases where autocompleting any of the fields prevents the "Get your estimate" button from becoming active.

## Additions

- Add `autocapitalize`, `autocomplete`, `autocorrect`, and `spellcheck` attributes to the DOB and salary inputs

## Testing

- Tested in Chrome, Safari, and my iPhone 6. The only way to enter data into the DOB and salary fields is now to type with whatever keyboard your device is using (well, other than copying and pasting, but I'm not even going there). That's important because the form is listening to `keyup` events to see if all the fields are completed and the "Get your estimate" button can be turned on; autocompleting a field doesn't fire a `keyup`.
- Can someone with an Android phone test this out to make sure you can't autocomplete any of the fields?

## Review

- @marteki
- @mistergone
- anyone else with a touch device who wants to check this out

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Visually tested in supported browsers and devices 