### PR TITLE
Add a loading indicator to improve the experience for long data retrieval times

### DIFF
--- a/retirement_api/static/retirement/css/claiming.css
+++ b/retirement_api/static/retirement/css/claiming.css
@@ -209,6 +209,10 @@ form {
   vertical-align: bottom;
 }
 
+#claiming-social-security #api-data-loading-indicator {
+  display: none;
+}
+
 #claim-canvas #indicator-handle {
   cursor: pointer;
 }
@@ -1986,5 +1990,38 @@ form {
 }
 .lt-ie8 .cf-icon-menu-round {
   *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '\e631');
+}
+
+/* Spinning icons for loading indicators */
+
+.cf-icon__spin {
+  -webkit-animation: cf-spin 2s infinite linear reverse;
+  animation: cf-spin 2s infinite linear reverse;
+}
+.cf-icon__pulse {
+  -webkit-animation: cf-spin 1s infinite steps(8) reverse;
+  animation: cf-spin 1s infinite steps(8) reverse;
+}
+@-webkit-keyframes cf-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes cf-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    -ms-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
 }
 

--- a/retirement_api/static/retirement/css/claiming.css
+++ b/retirement_api/static/retirement/css/claiming.css
@@ -211,6 +211,9 @@ form {
 
 #claiming-social-security #api-data-loading-indicator {
   display: none;
+  margin: 5px 0 0 5px;
+  font-size: 14px;
+  line-height: 6px;
 }
 
 #claim-canvas #indicator-handle {

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -114,7 +114,7 @@
           </div>
         </div>
         <div class="content-l_col content-l_col-1-3">
-          <button type="submit" id="get-your-estimates" class="get-your-estimates btn btn__disabled" disabled>{% trans "Get your estimates" %}</button>
+          <button type="submit" id="get-your-estimates" class="get-your-estimates btn btn__disabled" disabled>{% trans "Get your estimates" %} &nbsp; <span id="api-data-loading-indicator" class="cf-icon cf-icon-update cf-icon__spin" ></span></button>
         </div>
       </div>
     </form>

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -114,7 +114,7 @@
           </div>
         </div>
         <div class="content-l_col content-l_col-1-3">
-          <button type="submit" id="get-your-estimates" class="get-your-estimates btn btn__disabled" disabled>{% trans "Get your estimates" %} &nbsp; <span id="api-data-loading-indicator" class="cf-icon cf-icon-update cf-icon__spin" ></span></button>
+          <button type="submit" id="get-your-estimates" class="get-your-estimates btn btn__disabled" disabled>{% trans "Get your estimates" %}<span id="api-data-loading-indicator" class="cf-icon cf-icon-update cf-icon__spin" ></span></button>
         </div>
       </div>
     </form>

--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -114,7 +114,7 @@ function getData() {
       $(this).val( $(this).attr('data-base-value') + '-over50' );
     });
   }
-  $('#api-data-loading-indicator').css( 'display', 'inline' );
+  $('#api-data-loading-indicator').css( 'display', 'inline-block' );
   $.get( url )
     .done( function( dump ) {
       var data = dump.data;

--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -114,6 +114,7 @@ function getData() {
       $(this).val( $(this).attr('data-base-value') + '-over50' );
     });
   }
+  $('#api-data-loading-indicator').css( 'display', 'inline' );
   $.get( url )
     .done( function( dump ) {
       var data = dump.data;
@@ -155,6 +156,7 @@ function getData() {
 
         response = "error";
       }
+      $('#api-data-loading-indicator').css( 'display', 'none' );
     })
     .error( function(xhr, status, error) {
       // alert("An error occured! " + "\nError detail: " + xhr.responseText);


### PR DESCRIPTION
After the "Get Estimates" button is pressed, a spinning icon should appear to indicate to the user that data retrieval is occurring, and that the button click/tap was successful. It assures the user that the tool is working, and softens the uncertainty that might come from an unusually long wait time for results.

## Additions

* A `span` with an "api-data-loading-indicator" ID to the HTML file
* CSS code to hide the indicator by default, as well as to make the indicator spin
* Code in the JS to display the indicator when data retrieval begins, and hide it when it completes (or an error is received).

## Testing

- Tested in Mac Chrome and Android Chrome Beta 45.0.2454.21 with no issues.
- Tested in Safari 8.0.6. **The icon appeared and disappeared as expected, but spinning didn't occur despite `-webkit-` prefixes being included in the CSS for the animation.**

Requests for further testing in:
* iOS Safari
* iOS Chrome (if available)
* Mac Safari. Is the non-spinning replicable?
* IE 8+
* Firefox

July analytics for reference:
~36.5% IE, ~35% Chrome on some device, ~16.6% Safari (mostly on iOS), and ~7.5% Firefox.

## Review

* @mistergone
* @niqjohnson
* the original issue reporter @higs4281 

With special attention to testing in the browsers listed above, especially the IE, iOS, and Safari options.

## Screenshots

I think this deserves something better than a screenshot.

![loading-indicator](https://cloud.githubusercontent.com/assets/1183435/9119593/6a69b1b2-3c45-11e5-99b0-7443dc03c984.gif)


## Todos

* If it's really not spinning currently in Safari, how badly it needs to spin there? Is just having the icon appear and disappear enough? Determining if it's not spinning in iOS Safari is key for me on this.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Visually tested in supported browsers and devices 
* [ ] CHANGELOG has been updated