### PR TITLE
Fix tooltip padding at edges of screen

### DIFF
--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -187,6 +187,7 @@ function toolTipper( $elem ) {
       content = $( '[data-tooltip-name="' + name + '"]' ).html(),
       innerTip = ttc.find( '.innertip' ),
       outerTip = ttc.find( '.outertip' ),
+      pagePadding = parseInt( $( '#maincontent' ).css( 'padding-left' ) ),
       newTop,
       newLeft,
       tipset;
@@ -208,9 +209,8 @@ function toolTipper( $elem ) {
   outerTip.css('left', Math.floor( tipOffset - ( outerTip.outerWidth() / 2 ) ) );
 
   // Prevent tooltip from falling off the left side of screens
-  if (newLeft < 20) {
-    var elemCenter = $elem.offset().left + ( $elem.width() / 2 ),
-        pagePadding = 20;
+  if (newLeft < pagePadding) {
+    var elemCenter = $elem.offset().left + ( $elem.width() / 2 );
     ttc.css( 'left', pagePadding);
     innerTip.css( 'left', elemCenter - ( innerTip.outerWidth() / 2 ) - pagePadding );
     outerTip.css( 'left', elemCenter - ( outerTip.outerWidth() / 2 ) - pagePadding );
@@ -219,8 +219,7 @@ function toolTipper( $elem ) {
   // Prevent tooltip from falling off the right side of screens
   if ( ttc.offset().left + ttc.outerWidth(true) >$(window).width()) {
     var elemCenter = $elem.offset().left + ( $elem.width() / 2 ),
-        elemRightOffset = $(window).width() - elemCenter,
-        pagePadding = 20;
+        elemRightOffset = $(window).width() - elemCenter;
     newLeft = $(window).width() - ttc.outerWidth(true) - pagePadding;
     ttc.css( 'left', newLeft );
     innerTip.css( 'left', ttc.outerWidth() - ( innerTip.outerWidth() / 2 ) - elemRightOffset + pagePadding );

--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -187,7 +187,7 @@ function toolTipper( $elem ) {
       content = $( '[data-tooltip-name="' + name + '"]' ).html(),
       innerTip = ttc.find( '.innertip' ),
       outerTip = ttc.find( '.outertip' ),
-      pagePadding = parseInt( $( '#maincontent' ).css( 'padding-left' ) ),
+      pagePadding = parseInt( $( '#maincontent' ).css( 'padding-left' ), 10 ),
       newTop,
       newLeft,
       tipset;


### PR DESCRIPTION
Fix the alignment of tooltips to work with the new page paddings

## Additions

- Add `pagePadding` variable to `toolTipper()`

## Changes

- Tooltips near edges of screens now use `pagePadding` instead of a hard-coded number

## Testing

- Tooltips at the very edge of the screen should line up (i.e. no longer look like the screenshot in https://github.com/cfpb/retirement/pull/95#issuecomment-131238422)
- Tested and working on Chrome, Safari, Chrome's device emulator, and my iPhone 6

## Review

- @marteki
- @mistergone 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [x] Visually tested in supported browsers and devices