### PR TITLE
translation tweak to handle birth years 1955-1959

### DIFF
--- a/retirement_api/static/retirement/jsi18n/es/djangojs.js
+++ b/retirement_api/static/retirement/jsi18n/es/djangojs.js
@@ -9,20 +9,25 @@
   
 
   django.catalog = {
-    "is your full benefit claiming age.": "años de edad es su plena edad de jubilación.",
-    "is past your full benefit claiming age.": "años de edad es después de haber cumplido su plena edad de jubilación.",
-    "is your maximum benefit claiming age.": "años es la edad máxima para solicitar.",
+    "is your full benefit claiming age.": "de edad es su plena edad de jubilación.",
+    "is past your full benefit claiming age.": "de edad es después de haber cumplido su plena edad de jubilación.",
+    "is your maximum benefit claiming age.": "es la edad máxima para solicitar.",
     "62": "62 años",
     "63": "63 años",
     "64": "64 años",
     "65": "65 años",
     "66": "66 años",
+    "66 and 2 months": "66 años y 2 meses ",
+    "66 and 4 months": "66 años y 4 meses ",
+    "66 and 6 months": "66 años y 6 meses ",
+    "66 and 8 months": "66 años y 8 meses ",
+    "66 and 10 months": "66 años y 10 meses ",
     "67": "67 años",
     "68": "68 años",
     "69": "69 años",
     "70": "70 años",
-    "<strong>increases</strong> your benefit by&nbsp;<strong>": "años de edad, su beneficio <strong>aumentará</strong> un&nbsp;",
-    "<strong>reduces</strong> your monthly benefit by&nbsp;<strong>": "años de edad, su beneficio se <strong>reducirá</strong> un&nbsp;"
+    "<strong>increases</strong> your benefit by&nbsp;<strong>": "de edad, su beneficio <strong>aumentará</strong> un&nbsp;",
+    "<strong>reduces</strong> your monthly benefit by&nbsp;<strong>": "de edad, su beneficio se <strong>reducirá</strong> un&nbsp;"
   }
 
   django.gettext = function (msgid) {

--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -292,13 +292,13 @@ function setTextByAge() {
 
   // Set extra text for early and full retirement ages
   if ( selectedAge === 70 ) {
-    $( '.selected-retirement-age-value' ).text( 70 );
+    $( '.selected-retirement-age-value' ).text( gettext('70') );
   }
   else if ( selectedAge === SSData.earlyAge ) {
     $( '.selected-retirement-age-value' ).text( gettext(SSData.earlyRetirementAge) );
   }
   else if ( selectedAge === SSData.fullAge && SSData.currentAge < SSData.fullAge ) {
-    $( '.selected-retirement-age-value' ).text( gettext(SSData.fullRetirementAge)   );
+    $( '.selected-retirement-age-value' ).text( gettext(SSData.fullRetirementAge) );
   }
   else {
     $( '.selected-retirement-age-value' ).text( gettext(selectedAge) );

--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -295,13 +295,13 @@ function setTextByAge() {
     $( '.selected-retirement-age-value' ).text( 70 );
   }
   else if ( selectedAge === SSData.earlyAge ) {
-    $( '.selected-retirement-age-value' ).text( SSData.earlyRetirementAge );
+    $( '.selected-retirement-age-value' ).text( gettext(SSData.earlyRetirementAge) );
   }
   else if ( selectedAge === SSData.fullAge && SSData.currentAge < SSData.fullAge ) {
-    $( '.selected-retirement-age-value' ).text( SSData.fullRetirementAge   );
+    $( '.selected-retirement-age-value' ).text( gettext(SSData.fullRetirementAge)   );
   }
   else {
-    $( '.selected-retirement-age-value' ).text( selectedAge );
+    $( '.selected-retirement-age-value' ).text( gettext(selectedAge) );
   }
 
   // Graph content


### PR DESCRIPTION
cases where full retirement age took the form "66 and 6 months" required a little extra gettext yoga.

## Additions

- adding translations for the full retirement age value

## Changes
- claiming-graph.js and the translator djangojs

## Review

- @mistergone 
- @marteki 

## goal is this, for someone born in 1955:
<img width="413" alt="born_in_1955" src="https://cloud.githubusercontent.com/assets/515885/10074305/22b4183e-629d-11e5-9dad-3a2d7d397692.png">
