### PR TITLE
Fix prevention of selecting age younger than current

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,18 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chai": "^3.2.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
-    "gruntify-eslint": "^1.0.0",
+    "gruntify-eslint": "^1.0.0"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "chai-jq": "latest",
+    "jquery": "^1.11.0",
+    "jsdom": "latest",
+    "mocha-jsdom": "latest",
     "mocha": "^2.2.5"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,7 +1,23 @@
-var functions = require('../src/claiming-functions.js');
+if (typeof process === 'object') {
+  // Initialize node environment
+  global.chai = require('chai');
+  global.expect = require('chai').expect;
 
-var chai = require('chai');
-var expect = chai.expect;
+  var jsdom = require('jsdom');
+  var window = document = jsdom.jsdom().defaultView;
+  global.$ = global.jQuery = require('jquery');
+} else {
+  window.expect = window.chai.expect;
+  window.require = function () { /* noop */ };
+}
+
+var functions = require('../src/claiming-functions.js');
+var graph = require('../src/claiming-graph.js');
+
+
+/**
+ * Testing functions in claiming-functions.js
+ */
 
 describe( 'numToMoney...', function() {
   it( '...turn 5 into $5', function() {
@@ -103,5 +119,17 @@ describe( 'validDates...', function() {
   it( '...should understand leap years', function() {
     expect( functions.validDates( 2, 29, 2004 )['concat'] ).to.equal( '2-29-2004' );
     expect( functions.validDates( 2, 29, 2003 )['concat'] ).to.equal( '2-28-2003' );
+  });
+});
+
+
+/**
+ * Testing functions in claiming-graph.js
+ */
+
+describe( 'moveIndicatorToAge...', function() {
+  it( '...should prevent you from selecting an age less than your current age', function() {
+    expect( graph.moveIndicatorToAge( 63, 64 ) ).to.equal( false );
+    expect( graph.moveIndicatorToAge( 66, 69 ) ).to.equal( false );
   });
 });


### PR DESCRIPTION
This update corrects a bug whereby users could select (either via slider or via clicking the age number) an age younder than their current age.

**Review:**
- @ascott1
- @mistergone
- @higs4281

Includes a test to hopefully prevent future breakage.

_**Please do not deploy to production.**_ Only for testing on our dev server at the moment.