### PR TITLE
fix handling of decreases for some pre-FRA ages

### DIFF
--- a/retirement_api/utils/ss_calculator.py
+++ b/retirement_api/utils/ss_calculator.py
@@ -171,56 +171,51 @@ def interpolate_benefits(results, base, fra_tuple, current_age, DOB):
         elif current_age == 64:
             BENS['age 62'] = 0
             BENS['age 63'] = 0
-            BENS['age 64'] = int(round(base - first_penalty -
+            BENS['age 64'] = int(round(base -
+                                       first_penalty -
                                        (dob_month_delta * monthly_penalty)))
-            BENS['age 65'] = int(round(base -
-                                       (initial_step_back * monthly_penalty)))
+            BENS['age 65'] = int(round(base - first_penalty))
         elif current_age == 63:
             BENS['age 62'] = 0
             BENS['age 63'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (12 * monthly_penalty) -
                                        (dob_month_delta * monthly_penalty)))
             BENS['age 64'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (12 * monthly_penalty)))
-            BENS['age 65'] = int(round(base -
-                                       (initial_step_back * monthly_penalty)))
+            BENS['age 65'] = int(round(base - first_penalty))
         elif current_age == 62:
             BENS['age 62'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (2 * 12 * monthly_penalty) -
                                        (dob_month_delta *
                                         earlier_monthly_penalty)))
             BENS['age 63'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (2 * 12 * monthly_penalty)))
             BENS['age 64'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (12 * monthly_penalty)))
-            BENS['age 65'] = int(round(base -
-                                       (initial_step_back * monthly_penalty)))
+            BENS['age 65'] = int(round(base - first_penalty))
         elif current_age in range(55, 62):
             if DOB.day == 2:
                 BENS['age 62'] = int(round(base -
-                                           (initial_step_back *
-                                            monthly_penalty) -
+                                           first_penalty -
                                            (2 * 12 * monthly_penalty) -
                                            (12 * earlier_monthly_penalty)))
             else:
                 BENS['age 62'] = int(round(base -
-                                           (initial_step_back *
-                                            monthly_penalty) -
+                                           first_penalty -
                                            (2 * 12 * monthly_penalty) -
                                            (11 * earlier_monthly_penalty)))
             BENS['age 63'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (2 * 12 * monthly_penalty)))
             BENS['age 64'] = int(round(base -
-                                       (initial_step_back * monthly_penalty) -
+                                       first_penalty -
                                        (12 * monthly_penalty)))
-            BENS['age 65'] = int(round(base -
-                                       (initial_step_back * monthly_penalty)))
+            BENS['age 65'] = int(round(base - first_penalty))
     return results
 
 

--- a/retirement_api/utils/ss_calculator.py
+++ b/retirement_api/utils/ss_calculator.py
@@ -132,16 +132,20 @@ def interpolate_benefits(results, base, fra_tuple, current_age, DOB):
     if fra == 67:  # subject is 56 or younger, so age is not within the graph
         base = BENS['age 67']
         if DOB.day == 2:  # the born-on-the-2nd edge case
-            BENS['age 62'] = int(round(base - base*(3*12*(EARLY_PENALTY)) -
-                                       base*(2*12*EARLIER_PENALTY)))
+            BENS['age 62'] = int(round(base -
+                                       base * (3 * 12 * EARLY_PENALTY) -
+                                       base * (2 * 12 * EARLIER_PENALTY)))
         else:
-            BENS['age 62'] = int(round(base - base*(3*12*(EARLY_PENALTY)) -
-                                           base*(2*11*EARLIER_PENALTY)))
-        BENS['age 63'] = int(round(base - base*(3*12*(EARLY_PENALTY)) -
-                                       base*(1*12*EARLIER_PENALTY)))
-        BENS['age 64'] = int(round(base - base*(3*12*(EARLY_PENALTY))))
-        BENS['age 65'] = int(round(base - base*(2*12*(EARLY_PENALTY))))
-        BENS['age 66'] = int(round(base - base*(1*12*(EARLY_PENALTY))))
+            BENS['age 62'] = int(round(base -
+                                       base * (3 * 12 * EARLY_PENALTY) -
+                                       base * (12 * EARLIER_PENALTY) -
+                                       base * (11 * EARLIER_PENALTY)))
+        BENS['age 63'] = int(round(base -
+                                   base * (3 * 12 * EARLY_PENALTY) -
+                                   base * (12 * EARLIER_PENALTY)))
+        BENS['age 64'] = int(round(base - base * (3 * 12 * EARLY_PENALTY)))
+        BENS['age 65'] = int(round(base - base * (2 * 12 * EARLY_PENALTY)))
+        BENS['age 66'] = int(round(base - base * (1 * 12 * EARLY_PENALTY)))
         BENS['age 68'] = int(round(base + (base * ANNUAL_BONUS)))
         BENS['age 69'] = int(round(base + (2 * (base * ANNUAL_BONUS))))
         BENS['age 70'] = int(round(base + (3 * (base * ANNUAL_BONUS))))
@@ -153,6 +157,7 @@ def interpolate_benefits(results, base, fra_tuple, current_age, DOB):
         monthly_penalty = base * EARLY_PENALTY
         earlier_monthly_penalty = base * EARLIER_PENALTY
         dob_month_delta = 12 - get_months_past_birthday(DOB)
+        first_penalty = initial_step_back * monthly_penalty
         BENS['age 67'] = int(base + first_bump)
         BENS['age 68'] = int(base + first_bump + annual_bump)
         BENS['age 69'] = int(base + first_bump + (2 * annual_bump))
@@ -161,42 +166,61 @@ def interpolate_benefits(results, base, fra_tuple, current_age, DOB):
             BENS['age 62'] = 0
             BENS['age 63'] = 0
             BENS['age 64'] = 0
-            BENS['age 65'] = int(round(base - (monthly_penalty *
-                                               dob_month_delta)))
+            BENS['age 65'] = int(round(base -
+                                       (dob_month_delta * monthly_penalty)))
         elif current_age == 64:
             BENS['age 62'] = 0
             BENS['age 63'] = 0
-            BENS['age 64'] = int(round(base -
-                                       (12 * monthly_penalty) -
+            BENS['age 64'] = int(round(base - first_penalty -
                                        (dob_month_delta * monthly_penalty)))
-            BENS['age 65'] = int(round(base - (12 * monthly_penalty)))
+            BENS['age 65'] = int(round(base -
+                                       (initial_step_back * monthly_penalty)))
         elif current_age == 63:
             BENS['age 62'] = 0
             BENS['age 63'] = int(round(base -
-                                       (2 * 12 * monthly_penalty) -
+                                       (initial_step_back * monthly_penalty) -
+                                       (12 * monthly_penalty) -
                                        (dob_month_delta * monthly_penalty)))
-            BENS['age 64'] = int(round(base - (2 * 12 * monthly_penalty)))
-            BENS['age 65'] = int(round(base - (1 * 12 * monthly_penalty)))
+            BENS['age 64'] = int(round(base -
+                                       (initial_step_back * monthly_penalty) -
+                                       (12 * monthly_penalty)))
+            BENS['age 65'] = int(round(base -
+                                       (initial_step_back * monthly_penalty)))
         elif current_age == 62:
             BENS['age 62'] = int(round(base -
-                                       (3 * 12 * monthly_penalty) -
+                                       (initial_step_back * monthly_penalty) -
+                                       (2 * 12 * monthly_penalty) -
                                        (dob_month_delta *
                                         earlier_monthly_penalty)))
-            BENS['age 63'] = int(round(base - (3 * 12 * monthly_penalty)))
-            BENS['age 64'] = int(round(base - (2 * 12 * monthly_penalty)))
-            BENS['age 65'] = int(round(base - (1 * 12 * monthly_penalty)))
+            BENS['age 63'] = int(round(base -
+                                       (initial_step_back * monthly_penalty) -
+                                       (2 * 12 * monthly_penalty)))
+            BENS['age 64'] = int(round(base -
+                                       (initial_step_back * monthly_penalty) -
+                                       (12 * monthly_penalty)))
+            BENS['age 65'] = int(round(base -
+                                       (initial_step_back * monthly_penalty)))
         elif current_age in range(55, 62):
             if DOB.day == 2:
                 BENS['age 62'] = int(round(base -
-                                           (3 * 12 * monthly_penalty) -
+                                           (initial_step_back *
+                                            monthly_penalty) -
+                                           (2 * 12 * monthly_penalty) -
                                            (12 * earlier_monthly_penalty)))
             else:
                 BENS['age 62'] = int(round(base -
-                                           (3 * 12 * monthly_penalty) -
+                                           (initial_step_back *
+                                            monthly_penalty) -
+                                           (2 * 12 * monthly_penalty) -
                                            (11 * earlier_monthly_penalty)))
-            BENS['age 63'] = int(round(base - (3 * 12 * monthly_penalty)))
-            BENS['age 64'] = int(round(base - (2 * 12 * monthly_penalty)))
-            BENS['age 65'] = int(round(base - (1 * 12 * monthly_penalty)))
+            BENS['age 63'] = int(round(base -
+                                       (initial_step_back * monthly_penalty) -
+                                       (2 * 12 * monthly_penalty)))
+            BENS['age 64'] = int(round(base -
+                                       (initial_step_back * monthly_penalty) -
+                                       (12 * monthly_penalty)))
+            BENS['age 65'] = int(round(base -
+                                       (initial_step_back * monthly_penalty)))
     return results
 
 
@@ -262,6 +286,7 @@ def set_up_runvars(params):
     for age in chart_ages:
         benefits["age {0}".format(age)] = 0
     results = {'data': {
+                    'months_past_birthday': get_months_past_birthday(dob),
                     'early retirement age': '',
                     'full retirement age': '',
                     'benefits': benefits,
@@ -308,10 +333,11 @@ def get_retire_data(params, language):
     """
     Get a base full-retirement-age benefit from SSA's Quick Calculator
     and interpolate benefits for other claiming ages, handling edge cases:
-        - those born on Jan. 1 (see http://www.socialsecurity.gov/OACT/ProgData/nra.html)
-        - those born on 2nd day of any month (interpolator adds a month to reductions)
+        - those born on Jan. 1 -- see http://www.socialsecurity.gov/OACT/ProgData/nra.html
+        - those born on 1st day of amy month -- considered to be born the previous month
+        - those born on 2nd day of any month -- interpolator adds a month to reductions
         - those past full retirement age
-        - ages outside the parameters of our tool (< 22 or > 70)
+        - ages outside the parameters of our tool -- < 22 or > 70
         - users who enter earnings too low for benefits
         - dobs in 1950 that the Quick Calculator improperly treats as past FRA.
     """

--- a/retirement_api/utils/ss_utilities.py
+++ b/retirement_api/utils/ss_utilities.py
@@ -172,7 +172,7 @@ def past_fra_test(dob=None, language='en'):
     current_age = get_current_age(dob)
     months_plus = get_months_past_birthday(DOB)
     if DOB >= today:
-        return 'invalid birth year entered'
+        return get_note('too_young', language)
     # SSA has a special rule for people born on Jan. 1
     # http://www.socialsecurity.gov/OACT/ProgData/nra.html
     if DOB.month == 1 and DOB.day == 1:

--- a/retirement_api/utils/tests/test_ss_utilities.py
+++ b/retirement_api/utils/tests/test_ss_utilities.py
@@ -39,11 +39,11 @@ class UtilitiesTests(unittest.TestCase):
     }
 
     def test_months_past_birthday(self):
-        dob = self.today-timedelta(days=365*20)
+        dob = self.today-timedelta(days=(365 * 20) + 6)
         self.assertTrue(get_months_past_birthday(dob) == 0)
-        dob = self.today-timedelta(days=(365*20)+70)
+        dob = self.today-timedelta(days=(365 * 20) + 70)
         self.assertTrue(get_months_past_birthday(dob) == 2)
-        dob = self.today-timedelta(days=(365*20)+320)
+        dob = self.today-timedelta(days=(365 * 20) + 320)
         self.assertTrue(get_months_past_birthday(dob) == 10)
 
     def test_months_until_next_bday(self):
@@ -83,6 +83,7 @@ class UtilitiesTests(unittest.TestCase):
                                               },
                                  'params': self.sample_params,
                                  'disability': '',
+                                 'months_past_birthday': 0,
                                  'survivor benefits': {
                                         'child': '',
                                         'spouse caring for child': '',
@@ -96,7 +97,7 @@ class UtilitiesTests(unittest.TestCase):
                         'past_fra': False,
                         }
         benefits = {
-            'age 62': 1602,
+            'age 62': 1592,
             'age 63': 1696,
             'age 64': 1809,
             'age 65': 1960,
@@ -104,7 +105,7 @@ class UtilitiesTests(unittest.TestCase):
             'age 67': 2261,
             'age 68': 2442,
             'age 69': 2623,
-            'age 70': 2804,
+            'age 70': 2804
             }
         dob = self.today - datetime.timedelta(days=365*44)
         # results, base, fra_tuple, current_age, DOB
@@ -199,7 +200,7 @@ class UtilitiesTests(unittest.TestCase):
         self.assertTrue(past_fra_test(ok, language='en') == False)
         self.assertTrue("22" in past_fra_test(too_young, language='en'))
         self.assertTrue("sentimos" in past_fra_test(too_young, language='es'))
-        self.assertTrue("invalid birth" in past_fra_test(future, language='en'))
+        self.assertTrue("22" in past_fra_test(future, language='en'))
         self.assertTrue("70" in past_fra_test(way_old, language='en'))
         self.assertTrue(past_fra_test(edge, language='en') == True)
         self.assertTrue("invalid" in past_fra_test(invalid, language='en'))
@@ -285,6 +286,7 @@ class UtilitiesTests(unittest.TestCase):
                      u'benefits',
                      u'params',
                      u'disability',
+                     u'months_past_birthday',
                      u'survivor benefits']
         benefit_keys = ['age 62',
                         'age 63',
@@ -348,7 +350,7 @@ class UtilitiesTests(unittest.TestCase):
         self.assertTrue("past" in data['note'])
         self.sample_params['yob'] = self.today.year + 1
         data = get_retire_data(self.sample_params, language='en')
-        self.assertTrue("invalid" in data['note'])
+        self.assertTrue("22" in data['note'])
 
     @mock.patch('retirement_api.utils.ss_calculator.requests.post')
     def test_bad_calculator_requests(self, mock_requests):

--- a/retirement_api/utils/tests/test_ss_utilities.py
+++ b/retirement_api/utils/tests/test_ss_utilities.py
@@ -11,7 +11,7 @@ import unittest
 from ..ss_utilities import get_delay_bonus, get_months_past_birthday, yob_test
 from ..ss_utilities import get_retirement_age, get_months_until_next_birthday
 from ..ss_utilities import past_fra_test, get_current_age, age_map
-from ..ss_calculator import num_test, parse_details
+from ..ss_calculator import num_test, parse_details, clean_comment
 from ..ss_calculator import interpolate_benefits, get_retire_data
 from ..check_api import TimeoutError
 
@@ -37,6 +37,11 @@ class UtilitiesTests(unittest.TestCase):
         'dollars': 1,
         'prgf': 2
     }
+
+    def test_clean_comment(self):
+        test_comment = '<!-- This is a test comment    -->'
+        expected_comment = 'This is a test comment'
+        self.assertTrue(clean_comment(test_comment) == expected_comment)
 
     def test_months_past_birthday(self):
         dob = self.today-timedelta(days=(365 * 20) + 6)


### PR DESCRIPTION
Also lets the 'too-young' error message handle all too-young cases, even birth dates in the future.
Continuation of edge-case fixes.

## Changes

- adjustments to ss_calculator and ss_utilities 

## Testing
- for dob 8/20/1959 and $40000 earnings, claiming at age 65 should reduce benefits by 12%
- entering any valid date of [tomorrow's month]/[tomorrow's day]/1994 or higher, even into the future, will return the same "cannot provide an estimate if you are under 22" error message.
