### PR TITLE
Fix claiming phrase error, and avoid changelog merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+- Switched to `merge=union` for CHANGELOG.md in .gitattributes
+- fix 'claiming at 68' phrasing error
+
 ## 0.4.58
 - switch back to ssa.gov for our requests, after SSA started redirecting calls to socialsecurity.gov
 

--- a/src/claiming-graph.js
+++ b/src/claiming-graph.js
@@ -337,6 +337,7 @@ function setTextByAge() {
     var percent = ( SSData['age' + SSData.fullAge] - SSData['age' + selectedAge] ) / SSData['age' + SSData.fullAge];
     percent = Math.abs( Math.round( percent * 100 ) );
     $( '.benefit-modification-text' ).html( gettext('<strong>reduces</strong> your monthly benefit by&nbsp;<strong>') + percent + '</strong>%' );
+    $( '.compared-to-full' ).html( 'Compared to claiming at your full benefit claiming age.' );
     $( '.compared-to-full' ).show();
   }
   else if ( selectedAge > SSData.fullAge ) {
@@ -345,6 +346,8 @@ function setTextByAge() {
     $( '.benefit-modification-text' ).html( gettext('<strong>increases</strong> your benefit by&nbsp;<strong>') + percent + '</strong>%' );
     if ( SSData.past_fra ) {
       $( '.compared-to-full' ).html( 'Compared to claiming at ' + SSData.fullAge + '.' );
+    } else {
+      $( '.compared-to-full' ).html( 'Compared to claiming at your full benefit claiming age.' );
     }
     $( '.compared-to-full' ).show();
   }


### PR DESCRIPTION
This PR is a quick fix for the following bug:

> The phrase “compared to claiming at age 68” is showing up instead of "compared to claiming at FRA." This seems to happen only you reuse the calculator, use the graph to see benefit at age 68, not refresh, and the first example that you use is for someone past FRA and then resubmit with another date.

The fix does not accommodate Spanish translations. I marked that in the TODOs on this PR as a future change.

This PR also adds a `.gitattributes` file, to hopefully eliminate merge conflicts due to changelog edits.

## Additions

- Add additional phrase changes for `.compared-to-full` in the JS code
- Add `.gitattributes` file that switches to `merge=union` for CHANGELOG.md

## Testing

Let's compare between production and this PR. :smile: 

**Production:**
1. Load up the site.
2. Try the app with a birth date of April 15, 1947. Notice the 'Compared to claiming at 68.' phrasing, since the person is above their full retirement age.
3. Without refreshing the page, enter a birth date of 1951 or later. Notice the 'Compared to claiming at 68.' phrasing is still there, even though that is not their full retirement age.

**This PR:**
1. Load up the site.
2. Try the app with a birth date of April 15, 1947. Notice the 'Compared to claiming at 68.' phrasing, since the person is above their full retirement age.
3. Without refreshing the page, enter a birth date of 1951 or later. Notice the phrase changes as expected back to 'Compared to claiming at your full benefit claiming age.'

## Review

- @mistergone @niqjohnson @higs4281 @SerenaEstrella @hlortiz

## Todos

- Changing all the hard-coded English phrases within the JS to automatically access the Django translations instead. ¡Viva el Español!

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)