### PR TITLE
fix born-on-the-1st edge-case handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 - Switched to `merge=union` for CHANGELOG.md in .gitattributes
 - fix 'claiming at 68' phrasing error
+- Fix handling of birth dates on the first of a month
+- Fixes error message for ages over 70
 
 ## 0.4.58
 - switch back to ssa.gov for our requests, after SSA started redirecting calls to socialsecurity.gov

--- a/retirement_api/utils/ss_calculator.py
+++ b/retirement_api/utils/ss_calculator.py
@@ -30,9 +30,9 @@ import signal
 
 import dateutil
 from bs4 import BeautifulSoup as bs
-from .ss_utilities import get_retirement_age, get_current_age, past_fra_test
-from .ss_utilities import get_months_until_next_birthday
-from .ss_utilities import get_months_past_birthday
+from .ss_utilities import (get_retirement_age, get_current_age, past_fra_test,
+                           get_months_until_next_birthday,
+                           get_months_past_birthday)
 
 TIMEOUT_SECONDS = 20
 
@@ -66,11 +66,11 @@ def get_note(note_type, language):
     else:
         return ERROR_NOTES[note_type]['en']
 
-# base_url = "https://www.socialsecurity.gov"
-base_url = "https://www.ssa.gov"
-quick_url = "{0}/OACT/quickcalc/".format(base_url)  # where users go; not needed here
-result_url = "{0}/cgi-bin/benefit6.cgi".format(base_url)
-chart_ages = range(62, 71)
+# ORIGINAL_BASE_URL = "https://www.socialsecurity.gov  # NOW REDIRECTED"
+# QUICK_URL = "{0}/OACT/quickcalc/".format(BASE_URL)  # where users go
+BASE_URL = "https://www.ssa.gov"
+RESULT_URL = "{0}/cgi-bin/benefit6.cgi".format(BASE_URL)
+CHART_AGES = range(62, 71)
 
 comment = re.compile(r"<!--[\s\S]*?-->")  # regex for parsing indexing data
 
@@ -230,12 +230,18 @@ def interpolate_benefits(results, base, fra_tuple, current_age, DOB):
 def interpolate_for_past_fra(results, base, current_age, dob):
     """
     Calculate future benefits people who have passed full retirement age.
+    Handles edge case when subject is born on 1st and birthday is in the same month.
     """
     BENS = results['data']['benefits']
     annual_bump = round(base * ANNUAL_BONUS)
     monthly_bump = base * MONTHLY_BONUS
-    months_until_next_year = get_months_until_next_birthday(dob)
-    first_bump = round(monthly_bump * months_until_next_year)
+    first_bump = round(monthly_bump * get_months_until_next_birthday(dob))
+    if get_months_past_birthday(dob) == 11 and dob.day == 1:
+        current_age = current_age + 1
+        results['current_age'] = current_age
+        results['note'] = "Age {0} is past your full benefit claiming age.".format(current_age)
+        results['data']['months_past_birthday'] = 0
+        first_bump = annual_bump
     if current_age == 66:
         BENS['age 66'] = base
         BENS['age 67'] = base + first_bump
@@ -274,19 +280,24 @@ def interpolate_for_past_fra(results, base, current_age, dob):
 
 
 def set_up_runvars(params):
-    """set up the results container and variables"""
+    """set up the results container and variables and handle the MM/01/YYYY edge case"""
     dobstring = "{0}-{1}-{2}".format(params['yob'],
                                      params['dobmon'],
                                      params['dobday'])
-    dob = dateutil.parser.parse(dobstring).date()
-    # handle edge case for those born on Jan. 1
-    yobstring = params['yob']
-    if dob.month == 1 and dob.day == 1:
-        yob = int(params['yob']) - 1
-        yobstring = "{0}".format(yob)
+    yobstring = "{0}".format(params['yob'])
     current_age = get_current_age(dobstring)
+    dob = dateutil.parser.parse(dobstring).date()
+    # handle edge case for those born on first of the month
+    if dob.day == 1:
+        params['dobday'] = 2
+        if dob.month == 1:
+            yob = params['yob'] - 1
+            yobstring = "{0}".format(yob)
+            params['dobmon'] = 12
+        else:
+            params['dobmon'] = params['dobmon'] - 1
     benefits = {}
-    for age in chart_ages:
+    for age in CHART_AGES:
         benefits["age {0}".format(age)] = 0
     results = {'data': {
                     'months_past_birthday': get_months_past_birthday(dob),
@@ -308,11 +319,12 @@ def set_up_runvars(params):
                'past_fra': False,
                }
     fra_tuple = get_retirement_age(yobstring)  # returns tuple: (year, momths)
-    if fra_tuple[1]:
-        FRA = "{0} and {1} months".format(fra_tuple[0], fra_tuple[1])
-    else:
-        FRA = "{0}".format(fra_tuple[0])
-    results['data']['full retirement age'] = FRA
+    if isinstance(fra_tuple, tuple):
+        if fra_tuple[1]:
+            FRA = "{0} and {1} months".format(fra_tuple[0], fra_tuple[1])
+        else:
+            FRA = "{0}".format(fra_tuple[0])
+        results['data']['full retirement age'] = FRA
     return dob, dobstring, current_age, fra_tuple, results
 
 
@@ -328,8 +340,8 @@ def parse_response(results, html, language):
         results['note'] = get_note('down', language)
         return (results, 0)
     ret_amount = ret_amount_raw.text.split('.')[0].replace(',', '')
-    base = int(ret_amount)
-    return (results, base)
+    base_benefit = int(ret_amount)
+    return (results, base_benefit)
 
 
 def get_retire_data(params, language):
@@ -347,15 +359,16 @@ def get_retire_data(params, language):
 
     starter = datetime.datetime.now()
     (dob, dobstring, current_age, fra_tuple, results) = set_up_runvars(params)
+    ssa_params = results['data']['params']  # params adjusted for edge cases
     past_fra = past_fra_test(dobstring, language=language)
     if past_fra is False:
         retire_year_bd = dob.replace(year=dob.year + fra_tuple[0])
         retire_date = retire_year_bd + datetime.timedelta(days=30*fra_tuple[1])
-        params['retiremonth'] = retire_date.month
-        params['retireyear'] = retire_date.year
+        ssa_params['retiremonth'] = ssa_params['dobmon']
+        ssa_params['retireyear'] = retire_date.year
     elif past_fra is True:
-        params['retiremonth'] = starter.month
-        params['retireyear'] = starter.year
+        ssa_params['retiremonth'] = starter.month
+        ssa_params['retireyear'] = starter.year
         results['past_fra'] = True
         results['note'] = "Age {0} is past your full benefit claiming age.".format(current_age)
         results['data']['disability'] = "You have reached full retirement age and are not eligible for disability benefits."
@@ -374,7 +387,7 @@ def get_retire_data(params, language):
             results['error'] = past_fra
             return results
     try:
-        req = requests.post(result_url, data=params, timeout=TIMEOUT_SECONDS)
+        req = requests.post(RESULT_URL, data=ssa_params, timeout=TIMEOUT_SECONDS)
     except requests.exceptions.ConnectionError as e:
         results['error'] = "connection error at SSA's website: {0}".format(e)
         results['note'] = get_note('down', language)
@@ -397,18 +410,18 @@ def get_retire_data(params, language):
                                                            req.reason)
         results['note'] = get_note('down', language)
         return results
-    (results, base) = parse_response(results, req.text, language)
+    (results, base_benefit) = parse_response(results, req.text, language)
     if results['error']:
         return results
     if past_fra is True:
         final_results = interpolate_for_past_fra(results,
-                                                 base,
+                                                 base_benefit,
                                                  current_age,
                                                  dob)
     else:
-        results['data']['benefits']['age {0}'.format(fra_tuple[0])] = base
+        results['data']['benefits']['age {0}'.format(fra_tuple[0])] = base_benefit
         final_results = interpolate_benefits(results,
-                                             base,
+                                             base_benefit,
                                              fra_tuple,
                                              current_age,
                                              dob)

--- a/retirement_api/utils/ss_calculator.py
+++ b/retirement_api/utils/ss_calculator.py
@@ -348,12 +348,13 @@ def get_retire_data(params, language):
     """
     Get a base full-retirement-age benefit from SSA's Quick Calculator
     and interpolate benefits for other claiming ages, handling edge cases:
-        - those born on Jan. 1 -- see http://www.socialsecurity.gov/OACT/ProgData/nra.html
-        - those born on 1st day of amy month -- considered to be born the previous month
-        - those born on 2nd day of any month -- interpolator adds a month to reductions
         - those past full retirement age
         - ages outside the parameters of our tool -- < 22 or > 70
         - users who enter earnings too low for benefits
+        - those born on Jan. 1 -- see http://www.socialsecurity.gov/OACT/ProgData/nra.html
+        - those born on 1st day of any month -- considered to be born the previous month
+        - those born on 1st day of any month and who are within one month of their next birthday
+        - those born on 2nd day of any month -- interpolator adds a month to reductions
         - dobs in 1950 that the Quick Calculator improperly treats as past FRA.
     """
 

--- a/retirement_api/utils/ss_utilities.py
+++ b/retirement_api/utils/ss_utilities.py
@@ -25,11 +25,11 @@ del Seguro Social para estudiantes y trabajadores jóvenes.\
 """
 TOO_OLD = """\
 <span class="h4">Sorry, our tool cannot provide an estimate because \
-your birthdate, {0}, means you are older than 70 and are already receiving \
+your birthdate, {0}, means you are older than 70 and may already be receiving \
 benefits.</span> To check your benefits based on your actual \
 earnings record, contact the Social Security Administration or \
 open a <a href="http://www.socialsecurity.gov/myaccount/" target="_blank">\
-<em>my</em>Social Security</a> account.
+<em>my</em> Social Security</a> account.
 """
 TOO_OLD_ES = """\
 <span class="h4">Lo sentimos. No podemos estimar sus beneficios ya que \


### PR DESCRIPTION
This takes care of the trickiest edge case, those born on the 1st of a month

## Additions

- More utils tests 

## Changes
- Pares down and renames variables
- Adjusts ss_calculator utilities, mainly `set_up_runvars` 
- Fixes wording of over-70 error messge
* [x] CHANGELOG updated

## Testing
Here's how Hector's test cases should appear:  
##### DOB 4/1/1970 with income of $40,000 
- Formerly our site showed benefit at age 67 of **$1,485** (The value for being born in April 1970)
- SSA treats this combination as being born in March 1970 and returns a benefit of **$1,476** at age 67
- The new branch should show **$1,476**
- The new branch's API call `/retirement/retirement-api/estimator/4-1-1970/40000/` should show 'retiremonth' parameter of 3  

##### DOB 4/1/1947 with income of $40,000
- Formerly our site showed benefit **$1,422 at age 68**, the value for being born in April 1947.
- SSA treats this combination as being born in March 1947, thus making the subject 69, and returns a benefit of **$1,422 at age 69**. 
- The new branch should show **$1,422 at age 69**, even though the subject is technically 68 and 11 months. To match with SSA calculations and policy, we have to assume benefits start at age 69.
- The new branch's API call `/retirement/retirement-api/estimator/4-1-1947/40000/` should show 'retiremonth' parameter of 3 and a current age of 69 (which is just for purposes of this edge case)


##### Over 70 message
- for 4/15/1945, The error message should read like so:
<img width="798" alt="over_70" src="https://cloud.githubusercontent.com/assets/515885/13919698/75e60d3e-ef45-11e5-8d7d-38ef4e6e3e76.png">
  
## Review
- Hector can test this on build
- @marteki @niqjohnson @mistergone @hlortiz