### PR TITLE
About url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 *.egg-info
 .installed.cfg
 settings.py
+retirement_api/tests/logs/*
 
 # sqlite #
 #################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Fix handling of birth dates on the first of a month
 - Fixes error message for ages over 70
 - translate date placeholders and explanatory text for folks past FRA
+- added urls, view and empty templates for 'about' pages in English and Spanish
 
 ## 0.4.58
 - switch back to ssa.gov for our requests, after SSA started redirecting calls to socialsecurity.gov

--- a/retirement_api/templates/about-es.html
+++ b/retirement_api/templates/about-es.html
@@ -1,0 +1,3 @@
+{% extends base_template %}
+{% block content %}
+{% endblock %}

--- a/retirement_api/templates/about.html
+++ b/retirement_api/templates/about.html
@@ -1,0 +1,3 @@
+{% extends base_template %}
+{% block content %}
+{% endblock %}

--- a/retirement_api/urls.py
+++ b/retirement_api/urls.py
@@ -6,6 +6,8 @@ from django.conf import settings
 
 urlpatterns = patterns('',
     # url(r'^retirement-api/admin/', include(admin.site.urls)),
+    url(r'^about/$', 'retirement_api.views.about', name='about'),
+    url(r'^about/es/$', 'retirement_api.views.about', {'language': 'es'}, name='about-es'),
     url(r'^before-you-claim/$', 'retirement_api.views.claiming', name='claiming'),
     url(r'^before-you-claim/es/$', 'retirement_api.views.claiming', {'es': True}, name='claiming_es'),
     url(r'^retirement-api/estimator/(?P<dob>[^/]+)/(?P<income>\d+)/$', 'retirement_api.views.estimator', name='estimator'),

--- a/retirement_api/urls.py
+++ b/retirement_api/urls.py
@@ -6,8 +6,8 @@ from django.conf import settings
 
 urlpatterns = patterns('',
     # url(r'^retirement-api/admin/', include(admin.site.urls)),
-    url(r'^about/$', 'retirement_api.views.about', name='about'),
-    url(r'^about/es/$', 'retirement_api.views.about', {'language': 'es'}, name='about-es'),
+    url(r'^before-you-claim/about/$', 'retirement_api.views.about', name='about'),
+    url(r'^before-you-claim/about/es/$', 'retirement_api.views.about', {'language': 'es'}, name='about-es'),
     url(r'^before-you-claim/$', 'retirement_api.views.claiming', name='claiming'),
     url(r'^before-you-claim/es/$', 'retirement_api.views.claiming', {'es': True}, name='claiming_es'),
     url(r'^retirement-api/estimator/(?P<dob>[^/]+)/(?P<income>\d+)/$', 'retirement_api.views.estimator', name='estimator'),

--- a/retirement_api/utils/tests/test_ss_utilities.py
+++ b/retirement_api/utils/tests/test_ss_utilities.py
@@ -118,7 +118,7 @@ class UtilitiesTests(unittest.TestCase):
                         'past_fra': False,
                         }
         benefits = {
-            'age 62': 1583,
+            'age 62': 1592,
             'age 63': 1696,
             'age 64': 1809,
             'age 65': 1960,

--- a/retirement_api/views.py
+++ b/retirement_api/views.py
@@ -19,6 +19,11 @@ try:
 except:  # pragma: no cover
     standalone = False
 
+if standalone:
+    base_template = "standalone_base.html"
+else:
+    base_template = "%s/templates/base.html" % BASEDIR
+
 
 def claiming(request, es=False):
     if es is True:
@@ -38,10 +43,6 @@ def claiming(request, es=False):
     final_steps = {}
     for step in Step.objects.filter(title__contains='final_'):
         final_steps[step.title] = step
-    if standalone:
-        base_template = "standalone_base.html"
-    else:
-        base_template = "%s/templates/base.html" % BASEDIR
     cdict = {
         'tstamp': datetime.datetime.now(),
         'final_steps': final_steps,
@@ -124,3 +125,14 @@ def get_full_retirement_age(request, birth_year):
     else:
         data = json.dumps(data_tuple)
         return HttpResponse(data, content_type='application/json')
+
+
+def about(request, language='en'):
+    """Return our 'about' calculation-explainer page in Engish or Spanish"""
+    cdict = {
+        'base_template': base_template,
+        }
+    if language == 'en':
+        return render_to_response('about.html', cdict)
+    else:
+        return render_to_response('about-es.html', cdict)


### PR DESCRIPTION
Adds urls, view and empty templates for English and Spanish 'about' pages

## Additions

- urls, view, templates

## Testing

- `/retirement/before-you-claim/about/` should render and empty page with a footer

## Review

- @niqjohnson @marteki @mistergone 

## Screenshots

## Checklist

* [x] CHANGELOG has been updated

