### PR TITLE
Add startPath to browserSync task

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -7,6 +7,7 @@ var browserSync = require( 'browser-sync' );
 gulp.task( 'browserSync', function() {
   var port = util.env.port || '8000';
   browserSync.init( {
-    proxy: 'localhost:' + port
+    proxy: 'localhost:' + port,
+    startPath: './before-you-claim/'
   } );
 } );


### PR DESCRIPTION
Just a little developer quality of life fix to make BrowserSync show the right page when `gulp watch` is run

## Additions

- `startPath` to `browserSync` gulp task

## Testing

Running `gulp watch` should open a new browser tab with `http://localhost:3000/before-you-claim/` loaded in it (previously `gulp watch` opened a tab with `http://localhost:3000`, which doesn't resolve to anything in standalone right now).

## Review

- @mistergone or @marteki 