### PR TITLE
Fix phrasing for "compared to claiming at", plus misc bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Fixes error message for ages over 70
 - translate date placeholders and explanatory text for folks past FRA
 - added urls, view and empty templates for 'about' pages in English and Spanish
+- Fixed additional claiming phrasing errors
+- Removed final references to raphael-min.js and fixed spinner direction
 
 ## 0.4.58
 - switch back to ssa.gov for our requests, after SSA started redirecting calls to socialsecurity.gov

--- a/retirement_api/templates/base.html
+++ b/retirement_api/templates/base.html
@@ -95,7 +95,6 @@ And by the way, there’s another hidden message somewhere on the following page
       <link rel="stylesheet" href="{% static "retirement/css/main.min.css" %}">
   <!--<![endif]-->
 
-    <script src="{% static 'retirement/js/raphael-min.js' %}"></script>
     <script src="{% static "retirement/js/main.js" %}"></script>
 {% if es %}
     <script src="{% static "retirement/jsi18n/es/djangojs.js" %}"></script>

--- a/retirement_api/templates/standalone_base.html
+++ b/retirement_api/templates/standalone_base.html
@@ -89,9 +89,8 @@ And by the way, there’s another hidden message somewhere on the following page
       <link rel="stylesheet" href="{% static "retirement/css/main.min.css" %}">
   <!--<![endif]-->
 
-    <script src="{% static 'retirement/js/raphael-min.js' %}"></script>
     <script src="{% static "retirement/js/main.js" %}"></script>
-    
+
 {% if es %}
      <script src="{% static "retirement/jsi18n/es/djangojs.js" %}"></script>
  {% else %}

--- a/src/css/claiming.less
+++ b/src/css/claiming.less
@@ -496,8 +496,8 @@ form {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   background: url("../images/sus60s.png") no-repeat;
-  width: 200px; 
-  height: 200px; 
+  width: 200px;
+  height: 200px;
   padding-left: 200px; /* Move english image out of view */
 }
 
@@ -506,8 +506,8 @@ form {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   background: url("../images/gastos.png") no-repeat;
-  width: 200px; 
-  height: 200px; 
+  width: 200px;
+  height: 200px;
   padding-left: 200px; /* Move english image out of view */
 }
 
@@ -2054,12 +2054,12 @@ form {
 /* Spinning icons for loading indicators */
 
 .cf-icon__spin {
-  -webkit-animation: cf-spin 2s infinite linear reverse;
-  animation: cf-spin 2s infinite linear reverse;
+  -webkit-animation: cf-spin 2s infinite linear;
+  animation: cf-spin 2s infinite linear;
 }
 .cf-icon__pulse {
-  -webkit-animation: cf-spin 1s infinite steps(8) reverse;
-  animation: cf-spin 1s infinite steps(8) reverse;
+  -webkit-animation: cf-spin 1s infinite steps(8);
+  animation: cf-spin 1s infinite steps(8);
 }
 @-webkit-keyframes cf-spin {
   0% {
@@ -2083,4 +2083,3 @@ form {
     transform: rotate(359deg);
   }
 }
-

--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -365,9 +365,9 @@ var graphView = {
         var comparedToClaimingEsSplit = comparedToClaimingFullEs.split( 'XXX' );
         if ( typeof comparedToClaimingEsSplit !== 'undefined' ) {
           if ( comparedToClaimingEsSplit.length == 2 ) {
-            $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.fullAge + ' ' + comparedToClaimingEsSplit[1] );
+            $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.currentAge + ' ' + comparedToClaimingEsSplit[1] );
           } else {
-            $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.fullAge + '.' );
+            $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.currentAge + '.' );
           }
         }
       } else {

--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -364,7 +364,7 @@ var graphView = {
         var comparedToClaimingFullEs = window.gettext( 'Compared to claiming at' );
         var comparedToClaimingEsSplit = comparedToClaimingFullEs.split( 'XXX' );
         if ( typeof comparedToClaimingEsSplit !== 'undefined' ) {
-          if ( comparedToClaimingEsSplit.length == 2 ) {
+          if ( comparedToClaimingEsSplit.length === 2 ) {
             $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.currentAge + ' ' + comparedToClaimingEsSplit[1] );
           } else {
             $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.currentAge + '.' );

--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -362,11 +362,13 @@ var graphView = {
       if ( SSData.past_fra ) {
         percent = ( SSData['age' + SSData.currentAge] - SSData['age' + this.selectedAge] ) / SSData['age' + SSData.currentAge];
         var comparedToClaimingFullEs = window.gettext( 'Compared to claiming at' );
-        var comparedToClaimingEs = comparedToClaimingFullEs.split( 'XXX' );
-        if ( $.isArray( comparedToClaimingFullEs ) && ( comparedToClaimingFullEs.length == 2 ) ) {
-          $( '.compared-to-full' ).html( comparedToClaimingEs[0] + ' ' + SSData.fullAge + ' ' + comparedToClaimingEs[1] + '.' );
-        } else {
-          $( '.compared-to-full' ).html( comparedToClaimingEs[0] + ' ' + SSData.fullAge + '.' );
+        var comparedToClaimingEsSplit = comparedToClaimingFullEs.split( 'XXX' );
+        if ( typeof comparedToClaimingEsSplit !== 'undefined' ) {
+          if ( comparedToClaimingEsSplit.length == 2 ) {
+            $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.fullAge + ' ' + comparedToClaimingEsSplit[1] );
+          } else {
+            $( '.compared-to-full' ).html( comparedToClaimingEsSplit[0] + ' ' + SSData.fullAge + '.' );
+          }
         }
       } else {
         $( '.compared-to-full' ).html( window.gettext( 'Compared to claiming at your full benefit claiming age.' ) );

--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -363,7 +363,11 @@ var graphView = {
         percent = ( SSData['age' + SSData.currentAge] - SSData['age' + this.selectedAge] ) / SSData['age' + SSData.currentAge];
         var comparedToClaimingFullEs = window.gettext( 'Compared to claiming at' );
         var comparedToClaimingEs = comparedToClaimingFullEs.split( 'XXX' );
-        $( '.compared-to-full' ).html( comparedToClaimingEs[0] + SSData.fullAge + comparedToClaimingEs[1] );
+        if ( $.isArray( comparedToClaimingFullEs ) && ( comparedToClaimingFullEs.length == 2 ) ) {
+          $( '.compared-to-full' ).html( comparedToClaimingEs[0] + ' ' + SSData.fullAge + ' ' + comparedToClaimingEs[1] + '.' );
+        } else {
+          $( '.compared-to-full' ).html( comparedToClaimingEs[0] + ' ' + SSData.fullAge + '.' );
+        }
       } else {
         $( '.compared-to-full' ).html( window.gettext( 'Compared to claiming at your full benefit claiming age.' ) );
       }


### PR DESCRIPTION
This fixes phrasing on both the English and Spanish sites around the comparison to claiming at your full retirement age. It also ensures that the loading spinner points in and spins the correct direction, and removes some references to our former graphing library.

## Changes

- Fix phrasing about claiming at a user's full retirement age. The undefined values should be gone!

## Removals

- Removal of `raphael-min.js` calls from the base templates.

## Testing

Pull down the `claiming-phrasing` branch, and run `frontendbuild.sh`. Load the site.

If a person hasn't reached their full retirement age yet, the helper text explaining how their selected age compares to their full retirement age should say:

* English: "Compared to claiming at your full benefit claiming age."
* Español: "en comparación con su plena edad de jubilación."

If a person is over their full retirement age, the helper text should say:

* English: "Compared to claiming at XX." (where XX is their ~~full retirement~~ current age)
* Español: "en comparación con su beneficio a los XX años." (where XX is their ~~full retirement~~ current age)

The spinner on the Get Estimates button should face clockwise and spin clockwise.

There should also be no console errors about the lack of `raphael-min.js`.

## Review

- @higs4281 @niqjohnson 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)