### PR TITLE
Fix for decimal points in salary

### DIFF
--- a/src/js/utils/handle-string-input.js
+++ b/src/js/utils/handle-string-input.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Turns a string into a number.
+ * Assumes each number in the string should be preserved (unlike parseInt)
+ * Assumes the first instance of a decimal point is the intended one
+ * @param  {string} numberString  A string representing a number
+ * @returns {number} The assumed numeric value of numberString
+ */
+function handleStringInput( numberString ) {
+  if ( typeof numberString === 'number' ) {
+    return numberString;
+  }
+  var signMaker = 1,
+      minusPosition = numberString.indexOf( numberString.match( '-' ) ),
+      digitPosition = numberString.indexOf( numberString.match( /\d/ ) );
+
+  // If a '-' appears before the first digit, we assume numberString is negative
+  if ( numberString.indexOf( numberString.match( '-' ) ) !== -1 && minusPosition < digitPosition ) {
+    signMaker = -1;
+  }
+
+  // Strip non-numeric values, maintaining periods
+  numberString = numberString.replace( /[^0-9\.]+/g, '' );
+
+  // Strip any periods after the first
+  function replaceCommas( match, offset, full ) {
+    if ( offset === full.indexOf( '.' ) ) {
+      return '.';
+    }
+    return '';
+  }
+  numberString = numberString.replace( /\./g, replaceCommas );
+
+  // Get number value of string, then multiply by signMaker and return
+  return Number( numberString ) * signMaker;
+
+}
+
+module.exports = handleStringInput;

--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -2,6 +2,7 @@
 
 var numToMoney = require( '../utils/num-to-money' );
 var validDates = require( '../utils/valid-dates' );
+var strToNum = require( '../utils/handle-string-input' );
 var getModelValues = require( '../wizards/get-model-values' );
 var questionsView = require( './questions-view' );
 var fetch = require( '../wizards/fetch-api-data' );
@@ -97,7 +98,8 @@ var graphView = {
 
     // reformat salary
     $( '#salary-input' ).blur( function() {
-      var salary = numToMoney( $( '#salary-input' ).val().replace( /\D/g, '' ) );
+      var salaryNumber = strToNum( $( '#salary-input' ).val() ),
+          salary = numToMoney( salaryNumber );
       $( '#salary-input' ).val( salary );
     } );
 
@@ -203,7 +205,7 @@ var graphView = {
   getYourEstimates: function() {
     var dataLang = $( 'body' ).attr('data-lang'),
         dates = this.validateBirthdayFields(),
-        salary = $( '#salary-input' ).val().replace( /\D/g, '' ),
+        salary = strToNum( $( '#salary-input' ).val() ),
         SSData;
 
     // Hide warnings, show loading indicator

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,6 +6,7 @@ var numToMoney = require( '../src/js/utils/num-to-money' );
 var calculateAge = require( '../src/js/utils/calculate-age' );
 var enforceRange = require( '../src/js/utils/enforce-range' );
 var validDates = require( '../src/js/utils/valid-dates' );
+var handleStringInput = require( '../src/js/utils/handle-string-input' );
 
 
 describe( 'numToMoney...', function() {
@@ -112,13 +113,21 @@ describe( 'validDates...', function() {
 });
 
 
-/**
- * Testing functions in claiming-graph.js
- */
+describe( 'handleStringInput...', function() {
 
-// describe( 'moveIndicatorToAge...', function() {
-//   it( '...should prevent you from selecting an age less than your current age', function() {
-//     expect( graph.moveIndicatorToAge( 63, 64 ) ).to.equal( false );
-//     expect( graph.moveIndicatorToAge( 66, 69 ) ).to.equal( false );
-//   });
-// });
+  it( '...will parse number strings with non-numeric characters', function() {
+    expect( handleStringInput( '9a99' ) ).to.equal( 999 );
+    expect( handleStringInput( 'u123456' ) ).to.equal( 123456 );
+    expect( handleStringInput( '01234' ) ).to.equal( 1234 );
+    expect( handleStringInput( '$1,234,567' ) ).to.equal( 1234567 );
+    expect( handleStringInput( 'Ilikethenumber5' ) ).to.equal( 5 );
+    expect( handleStringInput( 'function somefunction() { do badstuff; }' ) ).to.equal( 0 );
+  });
+
+  it( '...will parse the first period as a decimal point', function() {
+    expect( handleStringInput( '4.22' ) ).to.equal( 4.22 );
+    expect( handleStringInput( 'I.like.the.number.5' ) ).to.equal( 0.5 );
+    expect( handleStringInput( '1.2.3.4.5.6.7' ) ).to.equal( 1.234567 );
+  });
+
+});


### PR DESCRIPTION
Decimal places in salary are being handled very poorly (they're simply removed, rather than rounded). This PR fixes that by rounded them (before being sent to the API).

## Additions
- `handle-string-input.js`, which may look familiar to fans of our previous albums
- Unit tests for `handle-string-input.js`

## Removals
- Some old commented-out code in the unit testing file.

## Changes
- Changed front-end to rely on `handle-string-input.js` utility instead of a too-simplistic REGEX replace.

## Testing
- Pull down, `gulp` and check it out.

## Review
- @marteki and @niqjohnson and @higs4281 

## Checklist
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Animated GIF
![liz-lemon-self-high5](https://cloud.githubusercontent.com/assets/1490703/14260869/a51fa79a-fa7b-11e5-81d6-ba883430c33d.gif)
