### PR TITLE
drop about-es template, set up about template and view for Spanish

### DIFF
--- a/retirement_api/templates/about-es.html
+++ b/retirement_api/templates/about-es.html
@@ -1,3 +1,0 @@
-{% extends base_template %}
-{% block content %}
-{% endblock %}

--- a/retirement_api/templates/about.html
+++ b/retirement_api/templates/about.html
@@ -1,4 +1,5 @@
 {% extends base_template %}
+{% load i18n %}
 {% block content %}
 <div class="nemo">
     <div class="wrapper-banner">

--- a/retirement_api/views.py
+++ b/retirement_api/views.py
@@ -129,10 +129,15 @@ def get_full_retirement_age(request, birth_year):
 
 def about(request, language='en'):
     """Return our 'about' calculation-explainer page in Engish or Spanish"""
+    if language == 'es':
+        activate('es')
+        es = True
+    else:
+        deactivate_all()
+        es = False
     cdict = {
         'base_template': base_template,
+        'available_languages': ['en', 'es'],
+        'es': es
         }
-    if language == 'en':
-        return render_to_response('about.html', cdict)
-    else:
-        return render_to_response('about-es.html', cdict)
+    return render_to_response('about.html', cdict)


### PR DESCRIPTION
This shouldn't affect the about page. It just prepares for eventual delivery of Spanish content.


## Additions

- load `i18n` tag
- adds language handling in the view

## Removals

- about-es template. we can use the same template, as with claiming.html

## Testing

- the 'about' page should be unchanged. 

## Review

- @niqjohnson @marteki @mistergone