### PR TITLE
Fix lowest bar message for users beween 62 and FRA

### DIFF
--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -338,7 +338,7 @@ var graphView = {
     } else {
       $( '.graph-content .content-container.full-retirement' ).show();
     }
-    if ( this.selectedAge === SSData.fullAge || this.selectedAge === SSData.currentAge ) {
+    if ( this.selectedAge === SSData.fullAge || ( this.selectedAge === SSData.currentAge && SSData.past_fra ) ) {
       if ( SSData.past_fra ) {
         if ( SSData.currentAge === 70 ) {
           $( '.benefit-modification-text' ).html( window.gettext('is your maximum benefit claiming age.') );


### PR DESCRIPTION
Fixes the `.benefit-modification-text` content for users between 62 and their full retirement age (see GHE/Retirement/bugs-and-issues/issues/187 for details)

## Changes

- `.benefit-modification-text` no longer reads "Age XX is your full benefit claiming age." for users between 62 and FRA who've selected the lowest bar in their graph.

## Testing

In the `low-bar-fix` branch, enter a birthdate that corresponds to an age between 62 and 66. Select the lowest bar on the graph. You should see a message like "Age XX reduces your monthly benefit by YY%" instead of "Age XX is your full benefit claiming age."

This fix should not change any other cases (users younger than 62, users past their full retirement page but younger than 70, users older than 70, etc.)

## Review

- @mistergone: Does that look like the right extra condition?
- @higs4281: Do you see any other cases that this change might break?

## Screenshots

### User born 1/1/1952, income of $40,000

Before | After
--------- | ------
![before](https://cloud.githubusercontent.com/assets/1862695/14291481/c693c422-fb31-11e5-8314-0e04b02935f7.png) | ![after](https://cloud.githubusercontent.com/assets/1862695/14291412/8170d7e0-fb31-11e5-9b98-a92c235ce1d8.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)