### PR TITLE
improve namespace of 'about' url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
--
+- Changed the url namespace for the 'about' page to be specific to retirement
 
 ## 0.4.61
 - Blanked out `about` page content pending clearance

--- a/retirement_api/tests/test_views.py
+++ b/retirement_api/tests/test_views.py
@@ -141,9 +141,9 @@ class ViewTests(TestCase):
         self.assertTrue(response.status_code == 400)
 
     def test_about_pages(self):
-        url = reverse('about')
+        url = reverse('retirement_about')
         response = client.get(url)
         self.assertTrue(response.status_code == 200)
-        url = reverse('about_es', kwargs={'language': 'es'})
+        url = reverse('retirement_about_es', kwargs={'language': 'es'})
         response = client.get(url)
         self.assertTrue(response.status_code == 200)

--- a/retirement_api/urls.py
+++ b/retirement_api/urls.py
@@ -6,8 +6,8 @@ from django.conf import settings
 
 urlpatterns = patterns('',
     # url(r'^retirement-api/admin/', include(admin.site.urls)),
-    url(r'^before-you-claim/about/$', 'retirement_api.views.about', name='about'),
-    url(r'^before-you-claim/about/es/$', 'retirement_api.views.about', {'language': 'es'}, name='about_es'),
+    url(r'^before-you-claim/about/$', 'retirement_api.views.about', name='retirement_about'),
+    url(r'^before-you-claim/about/es/$', 'retirement_api.views.about', {'language': 'es'}, name='retirement_about_es'),
     url(r'^before-you-claim/$', 'retirement_api.views.claiming', name='claiming'),
     url(r'^before-you-claim/es/$', 'retirement_api.views.claiming', {'es': True}, name='claiming_es'),
     url(r'^retirement-api/estimator/(?P<dob>[^/]+)/(?P<income>\d+)/$', 'retirement_api.views.estimator', name='estimator'),


### PR DESCRIPTION
Give the retirement 'about' page a more specific reference name.  
This should keep eregs pages from calling the retirement about page.

## Changes

- Makes the namespace 'retirement_about'
- Changes tests to match 

## Testing

- Simplest to test this on build.

## Review

- @willbarton @niqjohnson @marteki @mistergone 

* [x] CHANGELOG has been updated

