### PR TITLE
Address redundant CSS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
--
+- Remove redundant cf-icon CSS code
 
 ## 0.4.61
 - Blanked out `about` page content pending clearance

--- a/src/css/claiming.less
+++ b/src/css/claiming.less
@@ -1099,16 +1099,6 @@ form {
   user-select: none;
 }
 
-
-.cf-icon {
-  font-family: 'CFPB Minicons';
-  display: inline-block;
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  font-size: 18px;
-}
 .reset {
   margin: 0;
   padding: 0;

--- a/src/css/claiming.less
+++ b/src/css/claiming.less
@@ -1134,14 +1134,3 @@ form {
 .cf-icon-menu:before {
   content: "\e630";
 }
-/*
-.lt-ie8 .cf-icon-menu {
-  *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '\e630');
-}
-.cf-icon-menu-round:before {
-  content: "\e631";
-}
-.lt-ie8 .cf-icon-menu-round {
-  *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '\e631');
-}
-*/


### PR DESCRIPTION
This corrects the issue found in https://github.com/cfpb/retirement/issues/161. We were still explicitly defining `cf-icon` style rules even though we're now using Capital Framework, and it was conflicting with styles in the global footer.

Thanks for drawing our attention to the problem, @KimberlyMunoz!

## Removals

- Lines of CSS code for `cf-icon` in the Retirement-only CSS

## Review

- @kimberlymunoz @niqjohnson @higs4281 @mistergone 


## Checklist

* [x] CHANGELOG has been updated

