### PR TITLE
Lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
-- Remove redundant cf-icon CSS code
+- Added lifetime calculations to api and removed from js
+- Removed redundant cf-icon CSS code
 
 ## 0.4.62
 - Changed the url namespace for the 'about' page to be specific to retirement

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The "Before You Claim" page should load at `localhost:8000/before-you-claim/`.
 - You can use nose to run the Python test suite and see code coverage information:
 
   ```bash
-  nosetests --with-coverage --config=.coveragerc --cover-package retirement_api
+  ./pytest.sh
   ```
 - You can run the JavaScript tests with:
 

--- a/retirement_api/utils/ss_calculator.py
+++ b/retirement_api/utils/ss_calculator.py
@@ -133,7 +133,7 @@ def calculate_lifetime_benefits(results, base, fra_tuple, dob, past_fra):
             max_benefit = max_months * bar_value
             if year == AGE:
                 month_adjustment = results['data']['months_past_birthday']
-                if year == 62 and month_adjustment == 0:
+                if year == 62 and month_adjustment == 0 and dob.day != 2:
                     month_adjustment = 1
                 life_benefit = max_benefit - (month_adjustment * bar_value)
             elif year == 62:

--- a/src/js/models/lifetime-model.js
+++ b/src/js/models/lifetime-model.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/*
+  lifetimeModel is a class that stores lifetime benefit values for each claiming age.
+  */
+var lifetimeModel = {
+  values: {
+    'age62': 1,
+    'age63': 1,
+    'age64': 1,
+    'age65': 1,
+    'age66': 1,
+    'age67': 1,
+    'age68': 1,
+    'age69': 1,
+    'age70': 1
+  }
+};
+
+
+module.exports = lifetimeModel;
+

--- a/src/js/views/graph-view.js
+++ b/src/js/views/graph-view.js
@@ -27,6 +27,7 @@ var graphView = {
 
   init: function() {
     var SSData = getModelValues.benefits();
+    var lifetimeData = getModelValues.lifetime();
 
     $( 'input[name="benefits-display"]' ).click( function() {
       graphView.setTextByAge();
@@ -200,6 +201,7 @@ var graphView = {
     var dataLang = $( 'body' ).attr('data-lang'),
         dates = this.validateBirthdayFields(),
         salary = strToNum( $( '#salary-input' ).val() ),
+        lifetimeData,
         SSData;
 
     // Hide warnings, show loading indicator
@@ -209,6 +211,7 @@ var graphView = {
     $.when( fetch.apiData( dates.concat, salary, dataLang ) ).done( function( resp ) {
       if ( resp.error === '' ) {
         SSData = getModelValues.benefits();
+        lifetimeData = getModelValues.lifetime();
 
         $( '.step-two, #estimated-benefits-input, #graph-container' ).css( 'opacity', 1);
         $( '.step-two .question' ).css( 'display', 'inline-block' );
@@ -259,7 +262,8 @@ var graphView = {
   setTextByAge: function() {
     var gset = this.graphSettings,
         SSData = getModelValues.benefits(),
-        lifetimeBenefits = numToMoney( ( 85 - this.selectedAge ) * 12 * SSData['age' + this.selectedAge] ),
+        lifetimeData = getModelValues.lifetime(),
+        lifetimeBenefits = numToMoney( lifetimeData['age' + this.selectedAge] ),
         fullAgeBenefitsValue = SSData['age' + SSData.fullAge],
         benefitsValue = SSData['age' + this.selectedAge],
         $selectedBar,
@@ -269,11 +273,6 @@ var graphView = {
         fullAgeLeft,
         fullAgeTop,
         percent;
-
-    if ( SSData.currentAge > 62 ) {
-      lifetimeBenefits = numToMoney( ( ( 85 - this.selectedAge ) * 12 - SSData.monthsPastBirthday ) *
-        SSData['age' + this.selectedAge] );
-    }
 
     if ( $( '#estimated-benefits-input [name="benefits-display"]:checked' ).val() === 'annual' ) {
       benefitsValue *= 12;

--- a/src/js/wizards/get-model-values.js
+++ b/src/js/wizards/get-model-values.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var benefitsModel = require( '../models/benefits-model' );
+var lifetimeModel = require( '../models/lifetime-model' );
 
 var getModel = {
   benefits: function() {
     return benefitsModel.values;
+  },
+  lifetime: function() {
+    return lifetimeModel.values;
   }
 };
 

--- a/src/js/wizards/update-model.js
+++ b/src/js/wizards/update-model.js
@@ -1,13 +1,16 @@
 'use strict';
 
 var benefitsModel = require( '../models/benefits-model' );
+var lifetimeModel = require( '../models/lifetime-model' );
 
 var update = {
 
   benefits: function( prop, val ) {
     benefitsModel.values[prop] = val;
   },
-
+  lifetime: function( prop, val ) {
+    lifetimeModel.values[prop] = val;
+  },
   processApiData: function( resp ) {
     var data = resp.data,
         fullAge = Number( data['full retirement age'].substr( 0, 2 ) );
@@ -19,6 +22,9 @@ var update = {
         var prop = i.replace( ' ', '' );
         update.benefits( prop, val );
       }
+    } );
+    $.each( resp.data.lifetime, function( prop, val ) {
+        update.lifetime( prop, val );
     } );
     update.benefits( 'currentAge', resp.current_age );
     update.benefits( 'past_fra', resp.past_fra );


### PR DESCRIPTION
This fixes cases where we were overestimating lifetime benefit values 
and moves lifetime calculations into the api.

## Additions
- new `calculate_lifetime_benefits` function in `utils/ss_calculator`, plus tests
- new `lifetime-model` in `js/models`, plus supporting views and functions

## Deletions
- js code for calculating lifetime benefits

## testing
example DOBs from the @hlortiz test spreadsheet should match the "Should be" column for the given age.

I tested every combination in Hector's spreadsheet, plus every earlier birth year back to 1945, when our tool stops reporting.

## Review
@amymok, @mistergone, @niqjohnson, @marteki

## Checklist

* [x] CHANGELOG has been updated
