### PR TITLE
Show top nav menu in standalone

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -8,6 +8,6 @@ gulp.task( 'browserSync', function() {
   var port = util.env.port || '8000';
   browserSync.init( {
     proxy: 'localhost:' + port,
-    startPath: './before-you-claim/'
+    startPath: './retirement/before-you-claim/'
   } );
 } );

--- a/retirement_api/templates/standalone/base_update.html
+++ b/retirement_api/templates/standalone/base_update.html
@@ -56,7 +56,7 @@
     <link rel="stylesheet" href="/wp-content/themes/cfpb_nemo/_/c/eot.css">
     <![endif]-->
     <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/styles.css{{ STATIC_VERSION }}">
-   
+
     {% endblock %}
 
     {% block app_css %}
@@ -144,7 +144,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     script.src = 'http://search.usa.gov/javascripts/remote.loader.js';
     document.getElementsByTagName( 'head' )[0].appendChild( script );
 //]]>
-</script> 
+</script>
     {% block app_modal %}
     {% endblock %}
 
@@ -170,6 +170,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         }
     });
 </script>
-
+<script type="text/javascript" src="http://www.consumerfinance.gov/static/js/atomic/header.js"></script>
+<script type="text/javascript" src="http://www.consumerfinance.gov/static/js/atomic/footer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Add scripts needed to make the top nav menu work in standalone

## Additions

- `header.js` and `footer.js` scripts to the `standalone/base_update` template

## Changes

- gulp watch path to match the new standalone URL

## Testing

Running `gulp watch` from this branch should open a new browser tab that points to `http://localhost:3000/retirement/before-you-claim/`, and the page that loads there should have a working top navigation menu.

## Review

- @higs4281: Did I add those scripts in the right place in the right template?
- @mistergone or @marteki 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

![menu](https://cloud.githubusercontent.com/assets/1862695/14856678/162dadae-0c67-11e6-9997-d7d5aca82867.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)