### PR TITLE
Fix y-axis labels in IE 8 and IE 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Fix HTML validation errors
 - Removed calculate-age.js (unused)
 - Changed initial interaction for steps 2 and 3
+- Fix y-axis label in IE 8 and IE 9
 
 ## 0.4.7
 - Added lifetime calculations to api and removed from js

--- a/src/css/claiming.less
+++ b/src/css/claiming.less
@@ -63,13 +63,19 @@ form {
   /* Firefox */
   -moz-transform: rotate(-90deg);
 
-  /* IE */
-  -ms-transform: rotate(-90deg);
-
   /* Opera */
   -o-transform: rotate(-90deg);
 
-  /* Internet Explorer */
+  /* CSS3 */
+  transform: rotate(-90deg);
+
+  /* IE9 (this must come after the pure CSS3 to prevent autoprefixer from stripping it out) */
+  -ms-transform: rotate(-90deg);
+}
+
+.lt-ie9 #claiming-social-security p.y-axis-label {
+  top: 240px;
+  left: 0;
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
 }
 


### PR DESCRIPTION
Fix the y-axis label's position and rotation in IE 8 and IE 9

## Changes

- Y-axis CSS specific to IE 8 and IE 9

## Testing

You'll need to have a way to test this branch in IE 8 and IE 9, but if you do, the y-axis on the graph should look like the screenshots below.

## Review

- @marteki and/or @mistergone and/or @higs4281 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

### IE 8

Before | After
--------- | ------
![ie8-old](https://cloud.githubusercontent.com/assets/1862695/14864766/5d3c8f5e-0c89-11e6-8e45-339794d69955.png) | ![ie8-new](https://cloud.githubusercontent.com/assets/1862695/14864771/6101fb10-0c89-11e6-8f7b-8d6f942e4d56.png)

### IE 9

Before | After
--------- | ------
![ie9-old](https://cloud.githubusercontent.com/assets/1862695/14864782/6d9a6470-0c89-11e6-89ea-e0cc83b1afe7.png) | ![ie9-new](https://cloud.githubusercontent.com/assets/1862695/14864785/71299ad4-0c89-11e6-85dc-fa70e0c36a26.png)

## Todos

- We should double-check this in Saucelabs on build to be 100% sure the fixes work

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)