### PR TITLE
Fix the global eyebrow language list

### DIFF
--- a/retirement_api/templates/standalone/on-demand/header.html
+++ b/retirement_api/templates/standalone/on-demand/header.html
@@ -11,10 +11,10 @@
 <header class="o-header"
         role="banner">
 
-    
 
-    
-    
+
+
+
     <div class="m-global-eyebrow
                 m-global-eyebrow__horizontal">
         <div class="wrapper">
@@ -23,43 +23,43 @@
                 <span class="m-global-eyebrow_tagline-usa">United States Government</span>
             </div>
             <div class="m-global-eyebrow_actions">
-                <ul class="m-global-eyebrow_languages">
-                    <li>
+                <ul class="list__unstyled list__horizontal m-global-eyebrow_languages">
+                    <li class="list_item">
                         <a href="/es/" hreflang="es" lang="es">
                             Español
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/zh/" hreflang="zh" lang="zh">
                             中文
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/vi/" hreflang="vi" lang="vi">
                             Tiếng Việt
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ko/" hreflang="ko" lang="ko">
                             한국어
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/tl/" hreflang="tl" lang="tl">
                             Tagalog
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ru/" hreflang="ru" lang="ru">
                             Pусский
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ar/" hreflang="ar" lang="ar">
                             العربية
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ht/" hreflang="ht" lang="ht">
                             Kreyòl Ayisyen
                         </a>
@@ -76,16 +76,16 @@
     <div class="o-header_content no-js">
 
         <div class="wrapper">
-            
-            
-    
+
+
+
     <div class="m-global-header-cta
                 m-global-header-cta__horizontal">
         <a href="/complaint/">Submit a Complaint</a>
     </div>
 
 
-            
+
 
 <div class="m-global-search"
      data-js-hook="flyout-menu">
@@ -102,7 +102,7 @@
         <form class="m-global-search_content-form"
               action="http://search.consumerfinance.gov/search"
               method="get">
-            
+
             <input type="hidden"
                    name="utf8"
                    value="✓">
@@ -188,8 +188,8 @@
                 <!--<![endif]-->
             </a>
 
-            
-                
+
+
 
 
 
@@ -210,29 +210,29 @@
     <button class="o-mega-menu_trigger" data-js-hook="flyout-menu_trigger">
         <span class="u-visually-hidden">Menu</span>
     </button>
-    
-    
+
+
 <div class="o-mega-menu_content o-mega-menu_content-1
             u-hidden-overflow"
      aria-expanded="false"
      data-js-hook="flyout-menu_content">
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-1-wrapper">
-        
-            
-            
+
+
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-1-grid">
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-1-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-1-list">
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-1-item">
-        
-        
-    
+
+
+
     <div class="m-global-header-cta
                 m-global-header-cta__list">
         <a href="/complaint/">Submit a Complaint</a>
@@ -242,7 +242,7 @@
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-1-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-1-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
@@ -251,8 +251,8 @@
            data-js-hook=flyout-menu_trigger>
             Consumer Tools
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-2
             u-hidden-overflow"
      aria-expanded="false"
@@ -260,248 +260,248 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
-                    
-                    
+
+
                     <a class="u-link__disabled
                               o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
                               "
                        >
                         Consumer Tools Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/complaint/
            >
             Submit a Complaint
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/askcfpb/
            >
             Ask CFPB
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/your-story/
            >
             Tell Your Story
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/students/
            >
             Information for Students
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/older-americans/
            >
             Information for Older Americans
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/servicemembers/
            >
             Information for Servicemembers &amp; Veterans
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/paying-for-college/
            >
             Paying for College
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/owning-a-home/
            >
             Owning a Home
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/retirement/
            >
             Planning for Retirement
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/sending-money/
            >
             Sending Money Abroad
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/know-before-you-owe/
            >
             Know Before You Owe Mortgages
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/mortgagehelp/
            >
             Trouble Paying Your Mortgage?
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/fair-lending/
            >
             Protections Against Discrimination
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-1-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-1-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
@@ -510,8 +510,8 @@
            data-js-hook=flyout-menu_trigger>
             Educational Resources
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-2
             u-hidden-overflow"
      aria-expanded="false"
@@ -519,192 +519,192 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
-                    
-                    
+
+
                     <a class="u-link__disabled
                               o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
                               "
                        >
                         Educational Resources Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/your-money-your-goals/
            >
             Your Money, Your Goals
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/adult-financial-education/
            >
             Adult Financial Education
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/youth-financial-education/
            >
             Youth Financial Education
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/library-resources/
            >
             Resources for Libraries
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/tax-preparer-resources/
            >
             Resources for Tax Preparers
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/money-as-you-grow/
            >
             Resources for Parents
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/empowerment/
            >
             Information for Economically Vulnerable Consumers
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/managing-someone-elses-money/
            >
             Managing Someone Else’s Money
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=http://promotions.usa.gov/cfpbpubs.html
            >
             Free Brochures
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-1-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-1-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
@@ -713,8 +713,8 @@
            data-js-hook=flyout-menu_trigger>
             Data &amp; Research
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-2
             u-hidden-overflow"
      aria-expanded="false"
@@ -722,122 +722,122 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
                               "
                        href=/data-research/>
                         Data &amp; Research Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/data-research/research-reports/
            >
             Research &amp; Reports
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/data-research/consumer-complaints/
            >
             Consumer Complaint Database
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/data-research/mortgage-data-hmda/
            >
             Mortgage Database (HMDA)
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/data-research/credit-card-data/
            >
             Credit Card Surveys &amp; Agreements
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-1-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-1-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
@@ -846,8 +846,8 @@
            data-js-hook=flyout-menu_trigger>
             Policy &amp; Compliance
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-2
             u-hidden-overflow"
      aria-expanded="false"
@@ -855,37 +855,37 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
                               "
                        href=/policy-compliance/>
                         Policy &amp; Compliance Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
@@ -894,8 +894,8 @@
            data-js-hook=flyout-menu_trigger>
             Rulemaking
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-3
             u-hidden-overflow"
      aria-expanded="false"
@@ -903,117 +903,117 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
                               "
                        href=/policy-compliance/rulemaking/>
                         Rulemaking Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-3-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/rulemaking/final-rules/
            >
             Final Rules
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/rulemaking/rules-under-development/
            >
             Rules Under Development
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/rulemaking/regulatory-agenda/
            >
             Regulatory Agenda
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/rulemaking/small-business-review-panels/
            >
             Small Business Review Panels
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
@@ -1022,8 +1022,8 @@
            data-js-hook=flyout-menu_trigger>
             Compliance &amp; Guidance
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-3
             u-hidden-overflow"
      aria-expanded="false"
@@ -1031,98 +1031,98 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
                               "
                        href=/policy-compliance/guidance/>
                         Compliance &amp; Guidance Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-3-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/guidance/implementation-guidance/
            >
             Implementation &amp; Guidance
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/guidance/supervision-examinations/
            >
             Supervision &amp; Examinations
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/guidance/supervisory-highlights/
            >
             Supervisory Highlights
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
@@ -1131,8 +1131,8 @@
            data-js-hook=flyout-menu_trigger>
             Enforcement
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-3
             u-hidden-overflow"
      aria-expanded="false"
@@ -1140,103 +1140,103 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
                               "
                        href=/policy-compliance/enforcement/>
                         Enforcement Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-3-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/enforcement/actions/
            >
             Enforcement Actions
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/enforcement/petitions/
            >
             Petitions to Modify or Set Aside
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/enforcement/warning-letters/
            >
             Warning Letters
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
@@ -1245,8 +1245,8 @@
            data-js-hook=flyout-menu_trigger>
             Notices &amp; Opportunities to Comment
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-3
             u-hidden-overflow"
      aria-expanded="false"
@@ -1254,84 +1254,84 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
                               "
                        href=/policy-compliance/notice-opportunities-comment/>
                         Notices &amp; Opportunities to Comment Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-3-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/notice-opportunities-comment/open-notices/
            >
             Open Notices
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/notice-opportunities-comment/archive-closed/
            >
             Archive of Closed Notices
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
@@ -1340,8 +1340,8 @@
            data-js-hook=flyout-menu_trigger>
             Amicus Program
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-3
             u-hidden-overflow"
      aria-expanded="false"
@@ -1349,89 +1349,89 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
                               "
                        href=/policy-compliance/amicus/>
                         Amicus Program Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-3-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/amicus/briefs/
            >
             Filed Briefs
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/policy-compliance/amicus/suggest/
            >
             Suggest a Case
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-                
+
+
+
+
+
 <aside class="m-featured-menu-content
               ">
     <div class="m-featured-menu-content_text">
@@ -1453,22 +1453,22 @@
     </a>
 </aside>
 
-                
-            
-        
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-1-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-1-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
@@ -1477,8 +1477,8 @@
            data-js-hook=flyout-menu_trigger>
             About Us
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-2
             u-hidden-overflow"
      aria-expanded="false"
@@ -1486,145 +1486,145 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
                               "
                        href=/about-us/>
                         About Us Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/the-bureau/
            >
             The Bureau
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/budget-strategy/
            >
             Budget &amp; Strategy
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/payments-harmed-consumers/
            >
             Payments to Harmed Consumers
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/blog/
            >
             Blog
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/newsroom/
            >
             Newsroom
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/events/
            >
             Events
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/activity-log/
            >
             Recent Postings
         </a>
-        
+
     </li>
 </ul>
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-2-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         data-js-hook=flyout-menu>
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
                   o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
@@ -1633,8 +1633,8 @@
            data-js-hook=flyout-menu_trigger>
             Careers
         </a>
-        
-            
+
+
 <div class="o-mega-menu_content o-mega-menu_content-3
             u-hidden-overflow"
      aria-expanded="false"
@@ -1642,171 +1642,171 @@
 
     <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
         <div class="wrapper">
-            
-            
+
+
             <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
                     data-js-hook="flyout-menu_alt-trigger">
                 Back
             </button>
-            
+
             <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
-                
+
                 <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
-                    
-                    
+
+
                     <a class="
                               o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
                               "
                        href=/about-us/careers/>
                         Careers Overview
                     </a>
-                    
+
                 </span>
-                
+
                 <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
-                    
+
 <ul class="list
            list__unstyled
            o-mega-menu_content-list o-mega-menu_content-3-list">
-    
+
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/about-us/careers/working-at-cfpb/
            >
             Working @ CFPB
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/about-us/careers/application-process/
            >
             Job Application Process
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/about-us/careers/students-and-graduates/
            >
             Students &amp; Recent Graduates
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-3-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-3-link
-                  
+
                   "
            href=/about-us/careers/current-openings/
            >
             All Current Openings
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-            
-                
-            
-        
+
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/doing-business-with-us/
            >
             Doing Business With Us
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/advisory-groups/
            >
             Advisory Groups
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/project-catalyst/
            >
             Project Catalyst
         </a>
-        
+
     </li>
     <li class="list_item
                o-mega-menu_content-item o-mega-menu_content-2-item"
         >
-        
+
         <a class="
                   o-mega-menu_content-link o-mega-menu_content-2-link
-                  
+
                   "
            href=/about-us/contact-us/
            >
             Contact Us
         </a>
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-                
-                
+
+
+
 <aside class="m-featured-menu-content
               ">
     <div class="m-featured-menu-content_text">
@@ -1828,32 +1828,32 @@
     </a>
 </aside>
 
-                
-            
-                
-            
-        
+
+
+
+
+
         </div>
     </div>
 
-    
+
 
 </div>
 
-        
+
     </li>
 </ul>
 
                 </div>
             </div>
-            
-        
-        
+
+
+
     </div>
 
-    
-    
-    
+
+
+
     <div class="m-global-eyebrow
                 m-global-eyebrow__list">
         <div class="wrapper">
@@ -1911,13 +1911,13 @@
         </div>
     </div>
 
-    
+
 
 </div>
 
     <button class="o-mega-menu_tab-trigger" aria-hidden="true"></button>
 </nav>
-            
+
         </div>
 
     </div>


### PR DESCRIPTION
The global eyebrow language list started showing up as a bulleted list instead of a horizontal list in standalone. Adding a few missing classes to the language list fixes that.

## Changes

- Eyebrow language list markup
- A bunch of automatic whitespace removals (thanks, Sublime Text!)

## Testing

The list of languages in the eyebrow should look exactly like what's on production.

## Review

- @higs4281 and/or @mistergone and/or @marteki 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

`master` | `browlift`
-------- | ----------
![master](https://cloud.githubusercontent.com/assets/1862695/15197196/1d1ec8fe-179e-11e6-81d4-3d2987f365f2.png) | ![browlift](https://cloud.githubusercontent.com/assets/1862695/15197200/20e86c74-179e-11e6-98fe-ba21af9b83b0.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)