### PR TITLE
remove quoting from error messages to keep csv logs valid

### DIFF
--- a/retirement_api/utils/check_api.py
+++ b/retirement_api/utils/check_api.py
@@ -115,7 +115,7 @@ def run(base):
             signal.alarm(0)
             data = json.loads(test_request.text)
             collector.status = "%s" % test_request.status_code
-            collector.error = "{0}".format(data['error']).replace(',', ';')
+            collector.error = "{0}".format(data['error']).replace(',', ';').replace("'", '').replace('"', '')
             collector.note = data['note']
             collector.data = check_data(data)
             if collector.data == "BAD DATA":


### PR DESCRIPTION
Stop connection error messages from introducing bad quoting

- @amymok 

This hotfix will help keep our csv log clean.