### PR TITLE
Add calibration date to logging

### DIFF
--- a/retirement_api/utils/ssa_check.py
+++ b/retirement_api/utils/ssa_check.py
@@ -102,7 +102,8 @@ def check_results(test_data, TESTS):
                                 target_results['data']['params'][ssa_param_key],
                                 test_results['data']['params'][ssa_param_key])
     if OK:
-        return "All tests pass on {0}".format(today)
+        return ("All tests pass on {0}; "
+                "last recalibrated on {1}".format(today, calibration.created.date()))
     else:
         print error_msg
         return error_msg

--- a/retirement_api/utils/tests/test_ss_update_stats.py
+++ b/retirement_api/utils/tests/test_ss_update_stats.py
@@ -105,7 +105,7 @@ class UpdateSsStatsTests(TestCase):
         """
         url = 'http://www.socialsecurity.gov/OACT/ProgData/nra.html'
         soup = make_soup(url)
-        self.assertEqual(soup.find('h1').text, 'Social Security')
+        self.assertTrue('Social Security' in soup.find('h1').text)
 
     @mock.patch('requests.get')
     def test_make_soup_error(self, mock_requests):

--- a/retirement_api/utils/tests/test_ss_utilities.py
+++ b/retirement_api/utils/tests/test_ss_utilities.py
@@ -94,7 +94,8 @@ class SSACheckTests(django.test.TestCase):
 
 class UtilitiesTests(unittest.TestCase):
     today = datetime.date.today()
-    if today.day == 29:  # in case this test runs in Feb. in a leap year
+    # in case this test happens to run on a leap day; and yes, this happened
+    if today.day == 29 and today.month == 2:  # pragma: no cover
         today = today.replace(day=today.day - 1)
     sample_params = {
         'dobmon': 1,
@@ -278,7 +279,7 @@ class UtilitiesTests(unittest.TestCase):
             'age 70': 2698
             }
         dob = self.today.replace(year=self.today.year-44)
-        if dob.day == 2:
+        if dob.day == 2:  # pragma: no cover
             expected_benefits['age 62'] = 1523
         # need to pass results, base, fra_tuple, current_age, DOB
         results = interpolate_benefits(mock_results, 2176, (67, 0), 44, dob)


### PR DESCRIPTION
Knowing when the ssa_check test was last recalibrated will give CEE staffers
context about results of the bimonthly check of SSA benefit values.

## Changes

- Improves the ssa_check return message. 
- Tweaks two edge-case tests

## Review

- @amymok 
