### PR TITLE
Remove google analytics references

### DIFF
--- a/retirement_api/templates/base.html
+++ b/retirement_api/templates/base.html
@@ -101,18 +101,7 @@ And by the way, there’s another hidden message somewhere on the following page
 {% else %}
     <script src="{% static "retirement/jsi18n/en/djangojs.js" %}"></script>
 {% endif %}
-    <script src="{% static "js/analytics.js" %}"></script>
-
-    <!-- this is where we put our custom analytics -->
-    <script src="{% static 'nemo/_/js/analytics-global.js' %}"></script>
-
-    <!-- H5BP's Asynchronous Google Analytics snippet. -->
-    <script>
-      var _gaq=[['_setAccount','UA-20466645-3'],['_setDomainName', '.consumerfinance.gov'],['_trackPageview']];
-      (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-      g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-      s.parentNode.insertBefore(g,s)}(document,'script'));
-    </script>
+    
 
 </head>
 <body class="page" {% if es %}data-lang="es"{% else %}data-lang="en"{% endif %}>

--- a/retirement_api/templates/standalone/base_update.html
+++ b/retirement_api/templates/standalone/base_update.html
@@ -75,18 +75,7 @@
     {% endblock %}
 
     {% block analytics_js %}
-    <script src="http://www.consumerfinance.gov/static/js/analytics.js"></script>
-
-    <!-- this is where we put our custom analytics -->
-    <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/analytics-global.js"></script>
-
-    <!-- H5BP's Asynchronous Google Analytics snippet. -->
-    <script>
-      var _gaq=[['_setAccount','UA-20466645-3'],['_setDomainName', '.consumerfinance.gov'],['_trackPageview']];
-      (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-      g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-      s.parentNode.insertBefore(g,s)}(document,'script'));
-    </script>
+    
 
     {% endblock %}
 </head>

--- a/retirement_api/templates/standalone_base.html
+++ b/retirement_api/templates/standalone_base.html
@@ -96,18 +96,7 @@ And by the way, there’s another hidden message somewhere on the following page
  {% else %}
      <script src="{% static "retirement/jsi18n/en/djangojs.js" %}"></script>
  {% endif %}
-    <script src="http://www.consumerfinance.gov/static/js/analytics.js?ver=v4.2.10v4.2.24"></script>
-
-    <!-- this is where we put our custom analytics -->
-    <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/analytics-global.js?ver=v4.2.10v4.2.24"></script>
-
-    <!-- H5BP's Asynchronous Google Analytics snippet. -->
-    <script>
-      var _gaq=[['_setAccount','UA-20466645-3'],['_setDomainName', '.consumerfinance.gov'],['_trackPageview']];
-      (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-      g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-      s.parentNode.insertBefore(g,s)}(document,'script'));
-    </script>
+   
 
 {% block head_css %}{% endblock %}
 {% block head_js %}{% endblock %}


### PR DESCRIPTION
As part of the transition from Google Analytics to Google Tag Manager, remove old GA code which will be replaced in GTM
## Removals
- References to Google Analytics code 
## Review
- @user
## Checklist
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
