### PR TITLE
Allow Travis to build wheels and attach them to releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ after_success:
 - coveralls
 deploy:
   provider: releases
+  skip_cleanup: true
   api_key:
     secure: e24xlCO9zGNwFqicknFg/HAqui5duz2aQM2ruPFDpPbmw4rMD9ABYMq9DUqu/o4bXQMtCqH32fgaKnz6j4LYoMHEedPYpPuluszqXj2coHUoE+p93w/AYrGFiGfMukUtcW8xBxJnLJi4HOovKdSKqaravb7BCCtc/OjfcrPOn+g=
   file: 'dist/*.whl'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env: DJ_KEY=testkey
 install:
 - pip install -r requirements.txt
 - pip install coveralls
+before_script:
+    - npm install -g bower gulp-cli
+    - bower install
 script:
 - cp test_settings.py settings.py
 - ./manage.py migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
   skip_cleanup: true
   api_key:
     secure: e24xlCO9zGNwFqicknFg/HAqui5duz2aQM2ruPFDpPbmw4rMD9ABYMq9DUqu/o4bXQMtCqH32fgaKnz6j4LYoMHEedPYpPuluszqXj2coHUoE+p93w/AYrGFiGfMukUtcW8xBxJnLJi4HOovKdSKqaravb7BCCtc/OjfcrPOn+g=
+  file_glob: true
   file: 'dist/*.whl'
   on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: python
 python:
-  - "2.7"
+- '2.7'
+nodejs: 6
 cache: pip
 env: DJ_KEY=testkey
 install:
-  - pip install -r requirements.txt
-  - pip install coveralls
-script: 
-  - cp test_settings.py settings.py
-  - ./manage.py migrate
-  - coverage run --source='.' manage.py test
+- pip install -r requirements.txt
+- pip install coveralls
+script:
+- cp test_settings.py settings.py
+- ./manage.py migrate
+- coverage run --source='.' manage.py test
+- python2.7 setup.py bdist_wheel
 after_success:
-  - coveralls
+- coveralls
+deploy:
+  provider: releases
+  api_key:
+    secure: e24xlCO9zGNwFqicknFg/HAqui5duz2aQM2ruPFDpPbmw4rMD9ABYMq9DUqu/o4bXQMtCqH32fgaKnz6j4LYoMHEedPYpPuluszqXj2coHUoE+p93w/AYrGFiGfMukUtcW8xBxJnLJi4HOovKdSKqaravb7BCCtc/OjfcrPOn+g=
+  file: 'dist/*.whl'
+  on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 - ./manage.py migrate
 - coverage run --source='.' manage.py test
 - python2.7 setup.py bdist_wheel
+- ls dist/*
 after_success:
 - coveralls
 deploy:

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ def read_file(filename):
 
 setup(
     name='retirement',
-    version='0.5.6',
     author='CFPB',
     author_email='tech@cfpb.gov',
+    version_format='{tag}.dev{commitcount}+{gitsha}',
     maintainer='cfpb',
     maintainer_email='tech@cfpb.gov',
     packages=['retirement_api', 'retirement_api.utils'],
@@ -34,7 +34,7 @@ setup(
     ],
     long_description=read_file('README.md'),
     zip_safe=False,
-    setup_requires=['cfgov-setup==1.2', ],
+    setup_requires=['cfgov-setup==1.2', 'setuptools-git-version==1.0.3'],
     frontend_build_script='frontendbuild.sh',
 
 )


### PR DESCRIPTION
This was primarirly accomplished using the travis cli too:

`travis setup releases`

... And adding some code to make sure sure a wheel gets generated as part of the build process (including adding config for Node 6, bower, and gulp)

I also added 'setuptools-git-version' to setup.py, which will allow setuptools to infer the version number from the git tag