### PR TITLE
Open graph fixes

### DIFF
--- a/retirement_api/templates/about.html
+++ b/retirement_api/templates/about.html
@@ -3,6 +3,7 @@
 {% load static from staticfiles %}
 {% load i18n %}
 {% block title %} {% trans "About this tool" %} {% endblock %}
+{% trans page.title as TITLE %}
 {% block nemo_styles %}{% endblock %}
 {% block app_css %}
   <!--[if lt IE 9]>
@@ -25,6 +26,21 @@
 {% block responsive_nav %}
 <a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i>
     <span class="u-visually-hidden">Menu</span></a>
+{% endblock %}
+
+{% block page_meta %}
+  <meta property="og:title" content="{{ TITLE }} &gt; Consumer Financial Protection Bureau"/>
+  <meta property="og:url" content="{{ URL }}"/>
+
+  <meta name="description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
+
+  <meta property="og:description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
+{% endblock %}
+{% block open_graph_image %}
+  <meta property="og:image"
+        content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
+  <meta property="twitter:image"
+        content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
 {% endblock %}
 
 {% block content %}

--- a/retirement_api/templates/base.html
+++ b/retirement_api/templates/base.html
@@ -33,21 +33,25 @@ And by the way, there’s another hidden message somewhere on the following page
     <meta name="google-site-verification" content=""> <!-- http://google.com/webmasters -->
     <meta name="Copyright" content="Public domain">
 
-    <meta property="og:type" content="government">
+    <meta charset="UTF-8" />
+    <!-- Open Graph properties -->
+    {% block page_meta %}
+    <meta property="og:title" content="{{ TITLE }} &gt; Consumer Financial Protection Bureau"/>
+    <meta property="og:url" content=""/>
+    {% endblock %}
+    <meta property="og:type" content="government"/>
+    {% block open_graph_image %}
+    <meta property="og:image"
+          content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
+    <meta property="twitter:image"
+          content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
+    {% endblock %}
     <meta property="og:site_name" content="Consumer Financial Protection Bureau">
     <meta property="fb:app_id" content="210516218981921">
-
-
-    <meta property="og:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
-
-
-
-<meta charset="UTF-8" />
-<meta property="og:title" content="{{ TITLE }} &gt; Consumer Financial Protection Bureau"/>
-<meta property="og:type" content="government"/>
-<meta property="og:url" content=""/>
-
-
+    <meta property="og:site_name" content="Consumer Financial Protection Bureau">
+    <!-- Facebook -->
+    <meta property="fb:app_id" content="210516218981921">
+    <!-- End of Open Graph properties -->
 
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
@@ -75,10 +79,10 @@ And by the way, there’s another hidden message somewhere on the following page
     <link rel="stylesheet" href="{% static 'nemo/_/c/styles.css' %}">
 
 
-<!--     <link rel="stylesheet" href="{% static "retirement/static/landing/css/landing.css" %}"> -->
+    <!--     <link rel="stylesheet" href="{% static "retirement/static/landing/css/landing.css" %}"> -->
 
 
-<link rel='stylesheet' id='cfpb_icon_font-css'  href="{% static 'nemo/_/cfpb-icon-font/css/icons.css' %}" type="text/css" media="all">
+    <link rel='stylesheet' id='cfpb_icon_font-css'  href="{% static 'nemo/_/cfpb-icon-font/css/icons.css' %}" type="text/css" media="all">
     <!--[if IE 7]>
     <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="{% static 'nemo/_/cfpb-icon-font/css/icons-ie7.css' %}" type="text/css" media="all" />
     <![endif]-->

--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -3,6 +3,7 @@
 {% load static from staticfiles %}
 {% load i18n %}
 {% block title %} {% trans page.title %} {% endblock %}
+{% trans page.title as TITLE %}
 {% block nemo_styles %}
 {% endblock %}
 {% block app_css %}
@@ -28,15 +29,19 @@
 {% block page_meta %}
 {{ block.super }}
  {% if not es %}
-  <meta property="og:title" content="Planning for Retirement: Before you claim &gt; Consumer Financial Protection Bureau"/>
-  <meta property="og:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
-  <meta property="og:type" content="government"/>
+  <meta property="og:title" content="{{ TITLE }} &gt; Consumer Financial Protection Bureau"/>
   <meta property="og:url" content="{{ URL }}"/>
 
   <meta name="description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
 
   <meta property="og:description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
 {% endif %}
+{% endblock %}
+{% block open_graph_image %}
+  <meta property="og:image"
+        content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
+  <meta property="twitter:image"
+        content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
 {% endblock %}
 
 {% block page_viewport %}

--- a/retirement_api/templates/standalone_base.html
+++ b/retirement_api/templates/standalone_base.html
@@ -32,21 +32,26 @@ And by the way, there’s another hidden message somewhere on the following page
     <meta name="google-site-verification" content=""> <!-- http://google.com/webmasters -->
     <meta name="Copyright" content="Public domain">
 
-    <meta property="og:type" content="government">
+    <meta charset="UTF-8" />
+
+    <!-- Open Graph properties -->
+    {% block page_meta %}
+    <meta property="og:title" content="{{ TITLE }} &gt; Consumer Financial Protection Bureau"/>
+    <meta property="og:url" content=""/>
+    {% endblock %}
+    <meta property="og:url" content=""/>
+    {% block open_graph_image %}
+    <meta property="og:image"
+          content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
+    <meta property="twitter:image"
+          content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
+    {% endblock %}
     <meta property="og:site_name" content="Consumer Financial Protection Bureau">
     <meta property="fb:app_id" content="210516218981921">
-
-
-    <meta property="og:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">
-
-
-
-<meta charset="UTF-8" />
-<meta property="og:title" content="Paying for College &gt; Consumer Financial Protection Bureau"/>
-<meta property="og:type" content="government"/>
-<meta property="og:url" content=""/>
-
-
+    <meta property="og:site_name" content="Consumer Financial Protection Bureau">
+    <!-- Facebook -->
+    <meta property="fb:app_id" content="210516218981921">
+    <!-- End of Open Graph properties -->
 
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
@@ -93,9 +98,9 @@ And by the way, there’s another hidden message somewhere on the following page
 
 {% if es %}
      <script src="{% static "retirement/jsi18n/es/djangojs.js" %}"></script>
- {% else %}
+{% else %}
      <script src="{% static "retirement/jsi18n/en/djangojs.js" %}"></script>
- {% endif %}
+{% endif %}
    
 
 {% block head_css %}{% endblock %}


### PR DESCRIPTION
Cleans up the overrides for satellite apps' social sharing images. Adds images to remaining category pages.