### PR TITLE
Fix for meta tag on `/retirement/before-you-claim/`

### DIFF
--- a/retirement_api/templates/claiming.html
+++ b/retirement_api/templates/claiming.html
@@ -3,7 +3,6 @@
 {% load static from staticfiles %}
 {% load i18n %}
 {% block title %} {% trans page.title %} {% endblock %}
-{% trans page.title as TITLE %}
 {% block nemo_styles %}
 {% endblock %}
 {% block app_css %}
@@ -27,16 +26,14 @@
 {% endblock %}
 
 {% block page_meta %}
-{{ block.super }}
- {% if not es %}
-  <meta property="og:title" content="{{ TITLE }} &gt; Consumer Financial Protection Bureau"/>
-  <meta property="og:url" content="{{ URL }}"/>
-
-  <meta name="description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
-
-  <meta property="og:description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
+{% if not es %}
+<meta name="description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
+<meta property="og:description" content="The age you claim Social Security affects your lifetime income. Our Planning for Retirement tool helps you think through this decision."/>
 {% endif %}
+<meta property="og:title" content="{% trans page.title %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:url" content="{{ request.build_absolute_uri }}"/>
 {% endblock %}
+
 {% block open_graph_image %}
   <meta property="og:image"
         content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-retirement.original.png">


### PR DESCRIPTION
The `TITLE` variable isn't being set for some reason. This PR fixes that by using the `trans function` and removing the super call.  There is no need to call super for the standalone or front/base templates. 

-- Notes

The `request.build_absolute_uri` block is currently empty, not sure why.