### PR TITLE
Specify year in `test_get_test_params_in_january`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
 - '2.7'
-nodejs: 6
 cache: pip
 env: DJ_KEY=testkey
+before_install:
+- nvm use 6
 install:
 - pip install -r requirements.txt
 - pip install coveralls

--- a/retirement_api/utils/tests/test_ss_utilities.py
+++ b/retirement_api/utils/tests/test_ss_utilities.py
@@ -210,13 +210,13 @@ class UtilitiesTests(unittest.TestCase):
 
     @mock.patch('retirement_api.utils.ssa_check.datetime.date')
     def test_get_test_params_in_january(self, mock_date):
-        mock_date.today.return_value = self.today.replace(month=1, day=2)
+        mock_date.today.return_value = date(2017, 1, 2)
         test_params = get_test_params(46, 3)
         self.assertEqual(test_params['yob'], 1970)
-        mock_date.today.return_value = self.today.replace(month=1, day=27)
+        mock_date.today.return_value = date(2017, 1, 27)
         test_params = get_test_params(46, 28)
         self.assertEqual(test_params['yob'], 1970)
-        mock_date.today.return_value = self.today.replace(month=2, day=27)
+        mock_date.today.return_value = date(2017, 2, 27)
         test_params = get_test_params(46, 28)
         self.assertEqual(test_params['yob'], 1971)
 


### PR DESCRIPTION
Currently, this test will fail every year since it depends on numbers
based on "today" being in 2017.  Instead, we can just specify the year when we define
"today".

@chosak and I paired on this. 