### PR TITLE
Support optional testing of other databases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.3.2
 coverage==3.7.1
 Django==1.8.9
 django-filter==0.9.2
+dj-database-url==0.4.2
 lxml==3.6.0
 mock==1.0.1
 python-dateutil==2.2

--- a/test_settings.py
+++ b/test_settings.py
@@ -8,6 +8,8 @@ LANGUAGES = (
     ('en', _('English')),
 )
 
+import dj_database_url
+
 FIXTURE_DIRS = (
    '%s/retirement_api/fixtures/' % BASE_DIR,
 )
@@ -54,6 +56,9 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+
+if 'DATABASE_URL' in os.environ:
+    DATABASES['default'] = dj_database_url.config()
 
 LANGUAGE_CODE = 'en-us'
 


### PR DESCRIPTION
This change adds support for using the `DATABASE_URL` environment variable to specify Django's test database, based on the [dj-database-url](https://github.com/kennethreitz/dj-database-url) package.

It lets you run tests against e.g. Postgres:

```sh
$ DATABASE_URL=postgres://user@localhost/db ./pytest.sh
```

(Note that this will require first creating a local database and `pip install`ing `psycopg2==2.7.3.2`.)

It adds `dj-database-url==0.4.2` to the test requirements as that matches the current version in cfgov-refresh.

## Notes

- @chosak  and I paired on this. This is part of the work being done on platform#2567 to add Postgres compatibility to all cf.gov code. We're hoping to use this pattern with all satellite apps to make database testing easier everywhere.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
