### PR TITLE
Update external IRS links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,66 @@ guidance below.
 
 Generally speaking, you should fork this repository, make changes in your
 own fork, and then submit a pull-request. All new code should have associated unit
-tests that validate implemented features and the presence or lack of defects. 
-Additionally, the code should follow any stylistic and architectural guidelines 
+tests that validate implemented features and the presence or lack of defects.
+Additionally, the code should follow any stylistic and architectural guidelines
 prescribed by the project. In the absence of such guidelines, mimic the styles
 and patterns in the existing code-base.
+
+## Browser support
+
+We configure [Autoprefixer](#autoprefixer) to support the following list of browsers.
+
+- Latest 2 releases of all browsers including:
+    - Chrome
+    - Firefox
+    - Safari
+    - Internet Explorer
+    - Edge
+    - Opera
+    - iOS Safari
+    - Opera Mini
+    - Android Browser
+    - BlackBerry Browser
+    - Opera Mobile
+    - Chrome for Android
+    - Firefox for Android
+    - Samsung Internet
+- Internet Explorer 9
+- Internet Explorer 8
+- Internet Explorer 7
+
+http://browserl.ist/?q=last+2+versions%2C+Explorer+%3E%3D+8
+
+What this means to the end-user is we've added a level of backward
+compatability for modern features as much as possible. This doesn't
+necessarily mean feature parity. Where it's impossible or impractical to
+implement a modern feature, we fallback to standard practices for that browser.
+
+### Browser Testing
+
+For manual testing, we realistically test this project locally or in a virtual
+environment with the following list of browsers:
+
+- Chrome
+- Firefox
+- Safari
+- Internet Explorer 8, 9, 10, and 11
+- Edge
+- iOS Safari
+- Chrome for Android
+
+### Autoprefixer
+
+Autoprefixer parses our CSS and adds vendor prefixes to rules where necessary
+using reported feature support by [Can I Use](https://caniuse.com/). For more
+information visit the [Autoprefixer documentation site]
+(https://autoprefixer.github.io/).
+
+### Known feature differences
+
+- JavaScript: Unlike the main consumerfinance.gov project, this project does
+  serve interactive scripting to IE 8, but only for the retirement tool, not
+  for the header or footer scripting.
+- Icons: We currently use icon fonts to deliver scalable icons. Browsers that
+  do not support icon fonts unfortunately do not receive backups but we try to
+  always pair icons with text.

--- a/retirement_api/fixtures/retiredata.json
+++ b/retirement_api/fixtures/retiredata.json
@@ -70,7 +70,7 @@
 {
     "fields": {
         "note": "",
-        "instructions": "Your retirement income outside of Social Security will help you cover your expenses. You can increase your contributions to your retirement savings plans, or open and contribute to an <a href=\"http://www.irs.gov/Retirement-Plans/Individuals-Retirement-Arrangements---Getting-Started\" target=\"_blank\">IRA</a> plan.",
+        "instructions": "Your retirement income outside of Social Security will help you cover your expenses. You can increase your contributions to your retirement savings plans, or open and contribute to an <a href=\"https://www.irs.gov/retirement-plans/individuals-retirement-arrangements-getting-started\" target=\"_blank\">IRA</a> plan.",
         "title": "final_step_2_under"
     },
     "model": "retirement_api.step",
@@ -97,7 +97,7 @@
 {
     "fields": {
         "note": "",
-        "instructions": "While you wait to claim your benefits, you can continue growing your savings by making <a href=\"http://www.irs.gov/Retirement-Plans/Plan-Participant,-Employee/Retirement-Topics-Catch-Up-Contributions\" target=\"_blank\">catchup contributions</a> to your existing accounts. You may also be able to open and contribute to an <a href=\"http://www.irs.gov/Retirement-Plans/Individuals-Retirement-Arrangements---Getting-Started\" target=\"_blank\">IRA</a>.",
+        "instructions": "While you wait to claim your benefits, you can continue growing your savings by making <a href=\"https://www.irs.gov/retirement-plans/plan-participant-employee/retirement-topics-catch-up-contributions\" target=\"_blank\">catchup contributions</a> to your existing accounts. You may also be able to open and contribute to an <a href=\"https://www.irs.gov/retirement-plans/individuals-retirement-arrangements-getting-started\" target=\"_blank\">IRA</a>.",
         "title": "final_step_2_equal"
     },
     "model": "retirement_api.step",
@@ -106,7 +106,7 @@
 {
     "fields": {
         "note": "",
-        "instructions": "While you let your benefits continue to grow, you can keep working if you want. You can also stop working and use a portion of your savings to cover your needs. <a href=\"http://www.irs.gov/Retirement-Plans/Retirement-Plans-FAQs-regarding-IRAs-Distributions-(Withdrawals)\" target=\"_blank\">Learn the rules about withdrawing money</a> from your retirement accounts.",
+        "instructions": "While you let your benefits continue to grow, you can keep working if you want. You can also stop working and use a portion of your savings to cover your needs. <a href=\"https://www.irs.gov/retirement-plans/plan-participant-employee/retirement-topics-required-minimum-distributions-rmds\" target=\"_blank\">Learn the rules about withdrawing money</a> from your retirement accounts.",
         "title": "final_step_2_over"
     },
     "model": "retirement_api.step",

--- a/retirement_api/locale/es/LC_MESSAGES/django.po
+++ b/retirement_api/locale/es/LC_MESSAGES/django.po
@@ -487,8 +487,8 @@ msgid "Create a <a href=\"http://www.ssa.gov/myaccount/\" target=\"_blank\"><em>
 msgstr "Visite el <a href=\"http://www.ssa.gov/espanol/jubilacion2/calculadora.html\" target=\"_blank\">Calculador del Seguro Social</a> para ver la cantidad aproximada de sus beneficios basados en su propio registro de ganancias del Seguro Social. También encontrará información adicional sobre otros beneficios, incluyendo los beneficios por discapacidad y para sobrevivientes."
 
 #:
-msgid "Your retirement income outside of Social Security will help you cover your expenses. You can increase your contributions to your retirement savings plans, or open and contribute to an <a href=\"http://www.irs.gov/Retirement-Plans/Individuals-Retirement-Arrangements---Getting-Started\" target=\"_blank\">IRA</a> plan."
-msgstr "Sus ahorros le ayudarán a cubrir sus gastos durante su jubilación. Usted puede aumentar sus contribuciones a sus planes de jubilación, o abrir una <a href=\"http://www.irs.gov/Retirement-Plans/Individuals-Retirement-Arrangements---Getting-Started\" target=\"_blank\">cuenta IRA</a> (en inglés) y hacer contribuciones a estas cuentas."
+msgid "Your retirement income outside of Social Security will help you cover your expenses. You can increase your contributions to your retirement savings plans, or open and contribute to an <a href=\"https://www.irs.gov/retirement-plans/individuals-retirement-arrangements-getting-started\" target=\"_blank\">IRA</a> plan."
+msgstr "Sus ahorros le ayudarán a cubrir sus gastos durante su jubilación. Usted puede aumentar sus contribuciones a sus planes de jubilación, o abrir una <a href=\"https://www.irs.gov/retirement-plans/individuals-retirement-arrangements-getting-started\" target=\"_blank\">cuenta IRA</a> (en inglés) y hacer contribuciones a estas cuentas."
 
 #:
 msgid "If your income, employment, or marital status changes, you may need to reconsider your claiming age. Visit us again!"
@@ -499,16 +499,16 @@ msgid "which is your Social Security full retirement claiming age."
 msgstr " años, que es su plena edad de jubilación."
 
 #:
-msgid "While you wait to claim your benefits, you can continue growing your savings by making <a href=\"http://www.irs.gov/Retirement-Plans/Plan-Participant,-Employee/Retirement-Topics-Catch-Up-Contributions\" target=\"_blank\">catchup contributions</a> to your existing accounts. You may also be able to open and contribute to an <a href=\"http://www.irs.gov/Retirement-Plans/Individuals-Retirement-Arrangements---Getting-Started\" target=\"_blank\">IRA</a>."
-msgstr "Puede seguir aumentando sus ahorros y hacer contribuciones adicionales a las cuentas que ya tiene mientras espera para solicitar sus beneficios. También podría abrir una <a href=\"http://www.irs.gov/Retirement-Plans/Individuals-Retirement-Arrangements---Getting-Started\" target=\"_blank\">cuenta IRA</a> (en inglés) y hacer contribuciones a esta cuenta."
+msgid "While you wait to claim your benefits, you can continue growing your savings by making <a href=\"https://www.irs.gov/retirement-plans/plan-participant-employee/retirement-topics-catch-up-contributions" target=\"_blank\">catchup contributions</a> to your existing accounts. You may also be able to open and contribute to an <a href=\"https://www.irs.gov/retirement-plans/individuals-retirement-arrangements-getting-started\" target=\"_blank\">IRA</a>."
+msgstr "Puede seguir aumentando sus ahorros y hacer contribuciones adicionales a las cuentas que ya tiene mientras espera para solicitar sus beneficios. También podría abrir una <a href=\"https://www.irs.gov/retirement-plans/individuals-retirement-arrangements-getting-started\" target=\"_blank\">cuenta IRA</a> (en inglés) y hacer contribuciones a esta cuenta."
 
 #:
 msgid ", which is later than your Social Security full retirement claiming age."
 msgstr ", que es la edad máxima para reclamar sus beneficios de Seguro Social."
 
 #:
-msgid "While you let your benefits continue to grow, you can keep working if you want. You can also stop working and use a portion of your savings to cover your needs. <a href=\"http://www.irs.gov/Retirement-Plans/Retirement-Plans-FAQs-regarding-IRAs-Distributions-(Withdrawals)\" target=\"_blank\">Learn the rules about withdrawing money</a> from your retirement accounts."
-msgstr "Si lo desea, usted puede seguir trabajando mientras sus beneficios siguen aumentando. También puede dejar de trabajar y utilizar una parte de sus ahorros para cubrir sus necesidades económicas. Infórmese mejor sobre las normas para <a href=\"http://www.irs.gov/Retirement-Plans/Retirement-Plans-FAQs-regarding-IRAs-Distributions-(Withdrawals)\" target=\"_blank\">retirar dinero</a> (en inglés) de sus cuentas para la jubilación."
+msgid "While you let your benefits continue to grow, you can keep working if you want. You can also stop working and use a portion of your savings to cover your needs. <a href=\"https://www.irs.gov/retirement-plans/plan-participant-employee/retirement-topics-required-minimum-distributions-rmds\" target=\"_blank\">Learn the rules about withdrawing money</a> from your retirement accounts."
+msgstr "Si lo desea, usted puede seguir trabajando mientras sus beneficios siguen aumentando. También puede dejar de trabajar y utilizar una parte de sus ahorros para cubrir sus necesidades económicas. Infórmese mejor sobre las normas para <a href=\"https://www.irs.gov/retirement-plans/plan-participant-employee/retirement-topics-required-minimum-distributions-rmds\" target=\"_blank\">retirar dinero</a> (en inglés) de sus cuentas para la jubilación."
 
 #:
 msgid "Working in your 60s may increase your monthly benefit in a few ways. Because your benefits are based on your highest 35 years of earnings, each year of work can add higher earnings to your record by replacing years with low earnings, such as those when you were a student, were unemployed, or took time off. When you work and wait to claim until age 70, you can increase your monthly benefit by more than 75 percent!<span data-tooltip-target=\"claim_early_and_work\" class=\"cf-icon cf-icon-help-round\"></span> Working in your 60s also gives you more time to save on your own for retirement."


### PR DESCRIPTION
Some content moved on the IRS site. This corrects those links.

Testing:

- Run the setup instructions at https://github.com/cfpb/retirement#installation if you don't already have `retirement` set up
- Go to http://localhost:8000/retirement/before-you-claim/
- Verify that the links under Step 3 go to the new locations