### PR TITLE
minor cleanup of standalone settings

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,7 @@
 import os
+
+import dj_database_url
+
 from django.utils.translation import ugettext_lazy as _
 BASE_DIR = os.path.dirname(__file__)
 
@@ -6,12 +9,6 @@ SECRET_KEY = 'secret_for_testing_only'
 LANGUAGES = (
     ('es', _('Spanish')),
     ('en', _('English')),
-)
-
-import dj_database_url
-
-FIXTURE_DIRS = (
-   '%s/retirement_api/fixtures/' % BASE_DIR,
 )
 
 STANDALONE = True
@@ -24,7 +21,7 @@ ALLOWED_HOSTS = []
 
 TEMPLATE_DIRS = (
     '%s/retirement_api/templates' % BASE_DIR,
-    )
+)
 
 # Application definition
 


### PR DESCRIPTION
This cleans up a minor settings mistake for the sake of future content updates.

The standalone test_settings.py file specified a `FIXTURES_DIRS`, which isn't needed unless fixtures are in an unexpected place. This was causing the properly placed retiredata fixture to load twice, which is harmless but could worry someone updating content in the future.

As this only affects stand-alone operations, this does not need to be released or deployed. It can safely wait for the next code change that does need deployment.



