### PR TITLE
Add noopener attribute to window.open

### DIFF
--- a/retirement_api/static/retirement/admin/js/admin/RelatedObjectLookups.js
+++ b/retirement_api/static/retirement/admin/js/admin/RelatedObjectLookups.js
@@ -36,7 +36,7 @@ function showRelatedObjectLookupPopup(triggeringLink) {
     } else {
         href = triggeringLink.href + '?_popup=1';
     }
-    var win = window.open(href, name, 'height=500,width=800,resizable=yes,scrollbars=yes');
+    var win = window.open(href, name, 'height=500,width=800,noopener,resizable=yes,scrollbars=yes');
     win.focus();
     return false;
 }
@@ -61,7 +61,7 @@ function showAddAnotherPopup(triggeringLink) {
     } else {
         href  += '&_popup=1';
     }
-    var win = window.open(href, name, 'height=500,width=800,resizable=yes,scrollbars=yes');
+    var win = window.open(href, name, 'height=500,width=800,noopener,resizable=yes,scrollbars=yes');
     win.focus();
     return false;
 }


### PR DESCRIPTION
`noopener` should be added to `window.open` so that the new window does not have access back to the originating window, as checkmarx flags this as a security vulnerability. (Reported by @lfatty)

See https://developer.mozilla.org/en-US/docs/Web/API/Window/open#noopener