### PR TITLE
Deprecate use of lxml for html parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Tú puedes ver este app en español por poner `/es` al parte final del url.
  * [BeautifulSoup4](http://www.crummy.com/software/BeautifulSoup/bs4/doc/)
  * [Python-dateutil](https://dateutil.readthedocs.org/en/latest/)
  * [Requests](http://docs.python-requests.org/en/latest/)
- * [lxml](http://lxml.de/installation.html)
 
 ### For Python testing
  * [mock](https://mock.readthedocs.org/en/latest/)
@@ -49,18 +48,17 @@ git clone https://github.com/cfpb/retirement.git
 cd retirement
 setvirtualenvproject
 pip install -r requirements.txt
-cp test_settings.py settings.py
 ```
 
 Build the front-end requirements and the JavaScript files.
-  ```bash
-  ./frontendbuild.sh
-  ```
+```bash
+./frontendbuild.sh
+```
 
 Create a standalone database and load the app's tables and content.
 ```bash
 python manage.py migrate
-python manage.py loaddata retiredata.json
+python manage.py loaddata retirement_api/fixtures/retiredata.json
 ```
 
 Fire up a development server.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ coverage==3.7.1
 Django==1.8.9
 django-filter==0.9.2
 dj-database-url==0.4.2
-lxml==3.6.0
 mock==1.0.1
 python-dateutil==2.2
 requests==2.9.1

--- a/retirement_api/utils/ss_calculator.py
+++ b/retirement_api/utils/ss_calculator.py
@@ -399,7 +399,7 @@ def set_up_runvars(params, language='en'):
 
 
 def parse_response(results, html, language):
-    soup = bs(html, 'lxml')
+    soup = bs(html, 'html.parser')
     if soup.find('p') and 'insufficient to receive' in soup.find('p').text:
         results['error'] = "benefit is zero"
         results['note'] = get_note('earnings', language)

--- a/retirement_api/utils/ss_update_stats.py
+++ b/retirement_api/utils/ss_update_stats.py
@@ -3,7 +3,6 @@ import sys
 import datetime
 import json
 import csv
-import lxml
 
 """
 terms:
@@ -82,7 +81,7 @@ def make_soup(url):
                                                req.reason)
         return ''
     else:
-        soup = bs(req.text, 'lxml')
+        soup = bs(req.text, 'html.parser')
         return soup
 
 

--- a/retirement_api/utils/tests/test_ss_update_stats.py
+++ b/retirement_api/utils/tests/test_ss_update_stats.py
@@ -7,7 +7,6 @@ import shutil
 import tempfile
 import csv
 import datetime
-import lxml
 
 from bs4 import BeautifulSoup as bs
 import requests
@@ -64,7 +63,7 @@ class UpdateSsStatsTests(TestCase):
         mockpath = "{0}/mock_life.csv".format(self.tempdir)
         with open(self.life_page, 'r') as f:
             mockpage = f.read()
-        table = bs(mockpage, 'lxml').find('table').find('table')
+        table = bs(mockpage, 'html.parser').find('table').find('table')
         rows = table.findAll('tr')[2:]
         output_csv(mockpath, self.life_headings, rows)
         self.assertTrue(os.path.isfile(mockpath))
@@ -87,7 +86,7 @@ class UpdateSsStatsTests(TestCase):
         }
         with open(self.life_page, 'r') as f:
             mockpage = f.read()
-        table = bs(mockpage, 'lxml').find('table').find('table')
+        table = bs(mockpage, 'html.parser').find('table').find('table')
         rows = table.findAll('tr')[2:]
         output_json(mockpath, self.life_headings, rows)
         self.assertTrue(os.path.isfile(mockpath))
@@ -135,7 +134,7 @@ class UpdateSsStatsTests(TestCase):
         # arrange
         with open(self.earlyretire_page, 'r') as f:
             mockpage = f.read()
-        mock_soup.return_value = bs(mockpage, 'lxml')
+        mock_soup.return_value = bs(mockpage, 'html.parser')
 
         # action
         utils.ss_update_stats.update_example_reduction()
@@ -154,7 +153,7 @@ class UpdateSsStatsTests(TestCase):
         # arrange
         with open(self.life_page, 'r') as f:
             mockpage = f.read()
-        mock_soup.return_value = bs(mockpage, 'lxml')
+        mock_soup.return_value = bs(mockpage, 'html.parser')
 
         # action
         msg = utils.ss_update_stats.update_life()
@@ -174,7 +173,7 @@ class UpdateSsStatsTests(TestCase):
         # arrange
         with open(self.cola_page, 'r') as f:
             mockpage = f.read()
-        mock_soup.return_value = bs(mockpage, 'lxml')
+        mock_soup.return_value = bs(mockpage, 'html.parser')
 
         # action
         utils.ss_update_stats.update_cola()
@@ -191,7 +190,7 @@ class UpdateSsStatsTests(TestCase):
         # arrange
         with open(self.awi_page, 'r') as f:
             mockpage = f.read()
-        mock_soup.return_value = bs(mockpage, 'lxml')
+        mock_soup.return_value = bs(mockpage, 'html.parser')
 
         # action
         utils.ss_update_stats.update_awi_series()


### PR DESCRIPTION
This change removes the dependency and use of the [lxml](https://lxml.de/) library for parsing the HTML retrieved from the SSA. BeautifulSoup is instructed to use Python's `html.parser` instead.

See [the BS documentation](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser) for a quick comparison of the available parsers:

All functionality works properly, and unit tests all pass, when using this alternate parser. To test, follow the instructions in this repository's README.

You can see sample HTML output which gets parsed by this parser by running this curl command which hits the SSA quick calculator in the same way that this app does:

```sh
curl -v -d "dobmon=1&dobday=30&yob=1960&earnings=50000" https://www.ssa.gov/cgi-bin/benefit6.cgi
```

The returned HTML parses properly with the `html.parser` parser.

This repository also contains some HTML parsing as part of the `ss_update_stats` module, but this doesn't appear to be called either internally or externally. The related unit tests all pass. @higs4281 can you confirm how this is used, if at all?

This change closes #96 which describes a potential security risk from using lxml.