### PR TITLE
Disable package-lock.json on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
   - npm install -g bower gulp-cli
   - bower install
 script:
+- npm config set package-lock false
 - tox
 - python2.7 setup.py bdist_wheel
 - ls dist/*


### PR DESCRIPTION
Travis frontend builds run on a Linux platform, different from the Mac platform typically used for development. This can cause differences in the package-lock.json file due to the inclusion of optional modules.

See this lengthy npm thread that describes the problem:

https://github.com/npm/npm/issues/17722

To avoid this issue, this change runs `npm config set package-lock false` to disable the use of lock files when doing the npm install.

We already do something similar to this in Capital Framework:

https://github.com/cfpb/capital-framework/blob/821dd4fafb65b947ea436fd57b18a195f57e71b2/.travis.yml#L9

This change is needed because if the `package-lock.json` file is modified by the build, then the Python wheel name generated by [setuptools-git-version](https://pypi.org/project/setuptools-git-version/) is marked as dirty and won't match the latest tag. This has bitten us before on other repositories.