### PR TITLE
Remove django-filter, since it is never used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup
 install_requires = [
     'beautifulsoup4==4.3.2',
     'Django>=1.8,<1.12',
-    'django-filter==0.9.2',
     'dj-database-url==0.4.2',
     'python-dateutil==2.2',
     'requests==2.9.1',


### PR DESCRIPTION
This was causing a conflict when this satellite app was embedded in
cfgov-refresh because django-filter 0.9.2 isn't compatible with
djangorestframework 3.6.4 (which is necessary for cfgov-refresh as we
update to django 1.11).

We could have upgraded django-filter to a higher version, but since it
seems to be unused, we're simply removing it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing

