### PR TITLE
Restore boxsizing polyfill static file

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -85,6 +85,7 @@ module.exports = {
     },
     vendorjs: {
       src: [
+        loc.lib + '/box-sizing-polyfill/boxsizing.htc',
         loc.lib + '/html5shiv/dist/html5shiv-printshiv.min.js'
       ],
       dest: loc.dist + '/js/'

--- a/src/css/cf-theme-overrides.less
+++ b/src/css/cf-theme-overrides.less
@@ -155,7 +155,7 @@
 /* cf-grid
    ========================================================================== */
 
-@grid_box-sizing-polyfill-path: '/static/vendor/box-sizing-polyfill';
+@grid_box-sizing-polyfill-path: '/static/retirement/js';
 @grid_wrapper-width:            1230px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;


### PR DESCRIPTION
This project currently depends on [v1.0.0 of Capital Framework](https://github.com/cfpb/retirement/blob/31006089ba60b59283ef869b5db18f8d6c5047f8/bower.json#L17), which, in turn, has a dependency on [box-sizing-polyfill](https://github.com/cfpb/cf-grid/blob/1.0/bower.json#L25). This polyfill includes a boxsizing.htc file which is referenced by the version of cf-grid (1.0) pulled in by CF 1.0.0.

The cf-grid documentation [states](https://github.com/cfpb/cf-grid/blob/1.0/src/cf-grid.less#L18) that a `@grid_box-sizing-polyfill-path` Less variable must be defined to specify a root-relative location to this boxsizing.htc file.

Currently, this variable is set to `/static/vendor/box-sizing-polyfill`. This will only work if, in fact, the boxsizing.htc file lives at this location. Unfortunately, it no longer does -- in the past this perhaps
was pulled in by some other piece of cf.gov. But, as of #223, this project [no longer includes the file](https://github.com/cfpb/retirement/pull/223/files#diff-eddbfca195b18ab33db4917c1936198cL94) in its frontend build.

As of Django 1.11, running `manage.py collectstatic` when using ManifestStaticFilesStorage will fail if a referenced file is missing, e.g. if generated CSS has a `url("/static/vendor/box-sizing-polyfill/boxsizing.htc")` statement that refers to a non-existent file. So the fact that this project generates
CSS that refers to that missing file is now a problem.

In practice, this doesn't happen to cause trouble because deployments to servers that had this file at some point, and still have it locally in the Django static location, will continue to work. See GHE platform#3021 for a little more background on this.

To address this, this PR does two things:

1. It restores inclusion of boxsizing.htc into the frontend build. The build now copies this file under retirement_api/static/retirement/js.
2. It modifies the `@grid_box-sizing-polyfill-path` variable to point to /static/retirement/js, as this is now the proper path given the change in 1.

To test this, you can run ./frontendbuild.sh and observe that:

1. The file is properly copied to retirement_api/static/retirement/js/boxsizing.htc.
2. The generated CSS in retirement_api/static/retirement/css/main.min.css includes references to
/static/retirement/js/boxsizing.htc.

In order to properly test this behavior with ManifestStaticFilesStorage you'd have to install this changed branch into cfgov-refresh and run collecstatic there in a certain way; I've done that and will open a separate PR there that will enable easier testing of this kind of thing in the future.

(Note: a more general fix/improvement here would be modernizing the version of Capital Framework that this project uses, so that it isn't on 1.0.0, as the latest version no longer pulls in this polyfill. This would be a larger change, however, and so I propose this as an immediate fix.)