### PR TITLE
Fix tests that fail when run on certain days

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup_requires = [
 
 testing_extras = [
     'coverage>=4.5.1,<5',
+    'freezegun>=0.3.1,<1',
     'mock==2.0.0',
 ]
 


### PR DESCRIPTION
One unit test began failing recently:

[`retirement_api.utils.tests.test_ss_utilities.UtilitiesTests.test_interpolate_for_past_fra`](https://github.com/cfpb/retirement/blob/a2a9a590a0ae2ac5bf931f89129b136578cc7ae8/retirement_api/utils/tests/test_ss_utilities.py#L350)

This seems to caused by the way that some of this project's tests make use of `datetime.today` to determine the current day. This means that the tests are running using slightly different data depending on the day on which they are run. This makes it so that the edge cases of different date calculations may work one day but not the next.

To fix this particular error, this change brings in the Python [freezegun](https://github.com/spulec/freezegun) package that lets you "freeze time" when running tests. This dependency is only used when running tests, and won't be installed normally with this app.

This change fixes this particular test, which relates to the interpolation of benefits for retirees post-retirement age. I've added two tests that result in 100% coverage of [the method being tested](https://github.com/cfpb/retirement/blob/02869e95debbf3b1be51f0dad75e13c6752f9938/retirement_api/utils/ss_calculator.py#L270), along with some comments that attempt to explain the testing logic.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: