### PR TITLE
Change default webfont loading to use CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ The "Before You Claim" page should load at [localhost:8000/before-you-claim/](ht
 ### Fonts
 This application uses a proprietary licensed font (Avenir Next) that is not included in this repository.
 
-If you want to pull this font from a content delivery network (CDN), you can set
+By default it will try to load this font from the Fonts.com content delivery network (CDN).
+This behavior can be modified to instead try to load the font locally from
+the `retirement_api/static/retirement/webfonts/` directory by setting
 [`@use-font-cdn`](https://github.com/cfpb/retirement/blob/master/src/css/main.less#L29)
-to `true` and rebuild the assets with `gulp build`.
-
-If you instead want to install self-hosted fonts locally, you can place the font files
-in `retirement_api/static/retirement/webfonts/` and restart the local web server.
+to `false` and rebuilding the assets with `gulp build`. Restart the local web server
+once you've made this change.
 
 For Bureau employees or others with access to our private fonts repository,
 you can perform this step by creating a symbolic link to your local copy of

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -26,7 +26,7 @@
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '../webfonts';
 // Whether or not to override the local path and retrieve fonts from fonts.net.
-@use-font-cdn: false;
+@use-font-cdn: true;
 
 // Import the Capital Framework enhancements
 @import (less) "cf-enhancements.less";


### PR DESCRIPTION
This commit modifies the default loading strategy for our licensed font to use the Fonts.com CDN instead of looking for the file locally. This means that when building and loading this repository locally, the webfont will be loaded from the CDN. I've updated the README to indicate how this behavior may be changed if you want to load the font locally.

This is necessary because making the default local loading means that the built CSS includes references to a local `webfonts` directory that will not exist in a built Python package. This then fails Django `collectstatic` when run in a certain way.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: