### PR TITLE
Remove empty link to fix page

### DIFF
--- a/retirement_api/templates/retirement_api/claiming.html
+++ b/retirement_api/templates/retirement_api/claiming.html
@@ -284,8 +284,7 @@
           </div>
           <div class="lifestyle-response" data-responds-to="no-over50">
             <h4>{% trans questions.sixties.answer_no_b_subhed|safe %}</h4>
-            <p>{% trans questions.sixties.answer_no_a|safe %}</p>
-            <p><a href="https://www.socialsecurity.gov/planners/retire/stopwork.html" class="external-link" target="_blank" rel="noopener noreferrer"></a></p>
+            <p>{% trans questions.sixties.answer_no_b|safe %}</p>
           </div>
           <div class="lifestyle-response" data-responds-to="notsure-under50">
             <h4>{% trans questions.sixties.answer_unsure_a_subhed|safe %}</h4>


### PR DESCRIPTION
The retirement questions suddenly stopped rendering, and we found an empty link at the spot where the page was failing. Removing the empty link restores the questions.