### PR TITLE
Remove python 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 2.7
 - 3.6
 cache: pip
 install:
@@ -10,7 +9,7 @@ before_script:
 - npm config set package-lock false
 script:
 - tox
-- python2.7 setup.py bdist_wheel --universal
+- python3.6 setup.py bdist_wheel --universal
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 - npm config set package-lock false
 script:
 - tox
-- python3.6 setup.py bdist_wheel --universal
+- python setup.py bdist_wheel
 after_success:
 - coveralls
 deploy:

--- a/retirement_api/models.py
+++ b/retirement_api/models.py
@@ -1,8 +1,6 @@
 from django.db import models
 from django.template.defaultfilters import slugify
 
-from six import text_type
-
 
 WORKFLOW_STATE = [
     ('APPROVED', 'Approved'),
@@ -171,7 +169,7 @@ class Question(models.Model):
                     f.write(line.encode('utf-8'))
                 for phrase in phrases:
                     f.write('#: templates/claiming.html\n'.encode('utf-8'))
-                    f.write(text_type('msgid "%s"\n' % phrase).encode('utf-8'))
+                    f.write(str('msgid "%s"\n' % phrase).encode('utf-8'))
                     f.write('msgstr ""\n\n'.encode('utf-8'))
         else:
             return phrases

--- a/retirement_api/tests/test_commands.py
+++ b/retirement_api/tests/test_commands.py
@@ -1,7 +1,7 @@
 import mock
 import unittest
 
-from six import StringIO
+from io import StringIO
 
 from django.core.management import call_command
 

--- a/retirement_api/tests/test_views.py
+++ b/retirement_api/tests/test_views.py
@@ -12,8 +12,6 @@ from django.test import TestCase
 # import unittest
 from django.http import HttpRequest
 
-from six import binary_type
-
 from retirement_api.views import (param_check,
                                   income_check,
                                   estimator,
@@ -87,7 +85,7 @@ class ViewTests(TestCase):
     def test_estimator_url_data(self):
         request = self.req_blank
         response = estimator(request, dob='1955-05-05', income='40000')
-        self.assertIsInstance(response.content, binary_type)
+        self.assertIsInstance(response.content, bytes)
         rdata = json.loads(response.content)
         for each in self.return_keys:
             self.assertTrue(each in rdata.keys())
@@ -106,7 +104,7 @@ class ViewTests(TestCase):
         request = self.req_good
         response = estimator(request)
         self.assertTrue(response.status_code == 200)
-        self.assertIsInstance(response.content, binary_type)
+        self.assertIsInstance(response.content, bytes)
         rdata = json.loads(response.content)
         for each in self.return_keys:
             self.assertTrue(each in rdata.keys())

--- a/retirement_api/utils/ss_update_stats.py
+++ b/retirement_api/utils/ss_update_stats.py
@@ -14,7 +14,7 @@ terms:
 import requests
 # from django.template.defaultfilters import slugify
 from bs4 import BeautifulSoup as bs
-from six import StringIO
+from io import StringIO
 
 TODAY = datetime.datetime.now().date()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ install_requires = [
     'dj-database-url>=0.4.2,<1',
     'python-dateutil>=2.1<3',
     'requests>=2.18,<3',
-    'six>=1.11.0,<2',
 ]
 
 
@@ -49,7 +48,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{111}
+envlist=py{36}-dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -10,7 +10,6 @@ commands=
     coverage report --skip-covered -m
 
 basepython=
-    py27: python2.7
     py36: python3.6
 
 deps=


### PR DESCRIPTION
Remove python 2 from Tox testing, Travis, and setup.py.
Remove the `six` library.

## Testing

1. `tox`


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
