### PR TITLE
Include the language key for the mega menu

### DIFF
--- a/retirement_api/views.py
+++ b/retirement_api/views.py
@@ -56,8 +56,11 @@ def claiming(request, es=False):
         "base_template": base_template,
         "available_languages": ["en", "es"],
         "es": es,
+        "language": language,
         "about_view_name": "retirement_api:" + ("about_es" if es else "about"),
     }
+
+    print("Hello world")
 
     return render(request, "retirement_api/claiming.html", cdict)
 

--- a/retirement_api/views.py
+++ b/retirement_api/views.py
@@ -60,8 +60,6 @@ def claiming(request, es=False):
         "about_view_name": "retirement_api:" + ("about_es" if es else "about"),
     }
 
-    print("Hello world")
-
     return render(request, "retirement_api/claiming.html", cdict)
 
 


### PR DESCRIPTION
Resolves a bug around the mega menu presenting as its english version on the spanish claiming page.

## Additions

- Provides the language key into the claiming view.

## Testing

1. [Claiming Page in Spanish](http://localhost:8000/consumer-tools/retirement/before-you-claim/es/)

## Screenshots

![image](https://user-images.githubusercontent.com/16838497/90180651-4bc3e000-dd7d-11ea-9a3b-be92d33d9029.png)


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing

