### PR TITLE
Support LTS + Current versions of Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This application uses a proprietary licensed font (Avenir Next) that is not incl
 By default it will try to load this font from the Fonts.com content delivery network (CDN).
 This behavior can be modified to instead try to load the font locally from
 the `retirement_api/static/retirement/webfonts/` directory by setting
-[`@use-font-cdn`](https://github.com/cfpb/retirement/blob/master/src/css/main.less#L29)
+[`@use-font-cdn`](https://github.com/cfpb/retirement/blob/main/src/css/main.less#L29)
 to `false` and rebuilding the assets with `gulp build`. Restart the local web server
 once you've made this change.
 

--- a/retirement_api/templates/retirement_api/about.html
+++ b/retirement_api/templates/retirement_api/about.html
@@ -1,6 +1,5 @@
 {% extends base_template %}
-{% load staticfiles %}
-{% load static from staticfiles %}
+{% load static %}
 {% load i18n %}
 {% block title %} {% trans "About this tool" %} {% endblock %}
 {% trans page.title as TITLE %}

--- a/retirement_api/templates/retirement_api/claiming.html
+++ b/retirement_api/templates/retirement_api/claiming.html
@@ -1,6 +1,5 @@
 {% extends base_template %}
-{% load staticfiles %}
-{% load static from staticfiles %}
+{% load static %}
 {% load i18n %}
 {% block title %} {% trans page.title %} {% endblock %}
 {% block nemo_styles %}

--- a/retirement_api/templates/retirement_api/standalone/base_update.html
+++ b/retirement_api/templates/retirement_api/standalone/base_update.html
@@ -1,5 +1,4 @@
-{% load staticfiles %}
-{% load static from staticfiles %}
+{% load static %}
 {% load i18n %}
 <!DOCTYPE html>
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 install_requires = [
     "beautifulsoup4>=4.5.0,<4.9",
-    "Django>=1.11,<2.3",
+    "Django>=1.11,<3.2",
     "dj-database-url>=0.4.2,<1",
     "python-dateutil>=2.1,<3",
     "requests>=2.18,<3",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 install_requires = [
     "beautifulsoup4>=4.5.0,<4.9",
-    "Django>=1.11,<3.2",
+    "Django>=2.1,<3.2",
     "dj-database-url>=0.4.2,<1",
     "python-dateutil>=2.1,<3",
     "requests>=2.18,<3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36}-dj{111,22,31}
+envlist=lint,py{36}-dj{22,31}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -14,7 +14,6 @@ basepython=
     py38: python3.8
 
 deps=
-    dj111: Django>=1.11,<1.12
     dj22: Django>=2.2,<2.3
     dj31: Django>=3.1,<3.2
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36}-dj{111,22}
+envlist=lint,py{36}-dj{111,22,31}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,6 +16,7 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj22: Django>=2.2,<2.3
+    dj31: Django>=3.1,<3.2
 
 [testenv:lint]
 recreate=False
@@ -47,6 +48,5 @@ multi_line_output=3
 skip=.tox,migrations
 use_parentheses=1
 known_django=django
-known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
This change updates our supported version range to the LTS release of Django (2.2) and the current release of Django (3.1).
Removed support for Django 1.11

## Additions

- Added support for Django 3.1

## Removals

- {% load staticfiles %} and {% load admin_static %} were deprecated in Django 2.1, and removed in Django 3.0

## Testing

1. tox

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing