### PR TITLE
Show the Spanish mega-menu on about page

### DIFF
--- a/retirement_api/views.py
+++ b/retirement_api/views.py
@@ -144,5 +144,6 @@ def about(request, language="en"):
         "base_template": base_template,
         "available_languages": ["en", "es"],
         "es": es,
+        "language": language,
     }
     return render(request, "retirement_api/about.html", cdict)


### PR DESCRIPTION
Currently the Spanish version of the "About this tool" page shows the English mega-menu; it should show the Spanish mega-menu. (See GHE/CFGOV/platform/issues/3912 for more details.)

The about page just needed the same fix as we made in https://github.com/cfpb/retirement/pull/259

## Additions

- `language` key to the about page

## Testing

1. Install this version of the retirement app in cf.gov using the [method of your choice](https://cfpb.github.io/consumerfinance.gov/related-projects/#developing-python-packages-with-consumerfinancegov)
2. Go to /consumer-tools/retirement/before-you-claim/about/es/ and make sure the Spanish version of the mega-menu appears (and that all the other Spanish content continues to appear)
3. Go to /consumer-tools/retirement/before-you-claim/about/ and make sure the English version of the mega-menu continues to appear

## Screenshots

![es-about-page](https://user-images.githubusercontent.com/1862695/96308932-429bfd00-0fd2-11eb-8cd6-4c204bbfc599.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests