### PR TITLE
Add show_banner and show_mega_menu context vars to views

### DIFF
--- a/retirement_api/views.py
+++ b/retirement_api/views.py
@@ -57,6 +57,8 @@ def claiming(request, es=False):
         "available_languages": ["en", "es"],
         "es": es,
         "language": language,
+        "show_banner": True,
+        "show_mega_menu": True,
         "about_view_name": "retirement_api:" + ("about_es" if es else "about"),
     }
 
@@ -145,5 +147,7 @@ def about(request, language="en"):
         "available_languages": ["en", "es"],
         "es": es,
         "language": language,
+        "show_banner": True,
+        "show_mega_menu": True,
     }
     return render(request, "retirement_api/about.html", cdict)


### PR DESCRIPTION
In conjunction with a forthcoming PR to consumerfinance.gov, these will enable the banner on Beta and requesting the Spanish mega menu explicitly instead of relying on a default.


## Additions

- Context variables `show_banner` and `show_mega_menu` on the `claiming` and `about` views


## Testing

[To be filled in once related cf.gv PR is open.]

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
